### PR TITLE
mingw build: ignore failure of 'DEL' commands

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -289,7 +289,7 @@ RESOURCE = libcurl.res
 all: $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
 
 $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
-	@$(call DEL, $@)
+	@-$(call DEL, $@)
 	$(AR) cru $@ $(libcurl_a_OBJECTS)
 	$(RANLIB) $@
 	$(STRIP) $@
@@ -297,7 +297,7 @@ $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 # remove the last line above to keep debug info
 
 $(libcurl_dll_LIBRARY): $(libcurl_a_OBJECTS) $(RESOURCE) $(libcurl_dll_DEPENDENCIES)
-	@$(call DEL, $@)
+	@-$(call DEL, $@)
 	$(CC) $(LDFLAGS) -shared -o $@ \
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY) \
 	  $(libcurl_a_OBJECTS) $(RESOURCE) $(DLL_LIBS)
@@ -323,5 +323,3 @@ $(PROOT)/include/curl/curlbuild.h:
 
 $(LIBCARES_PATH)/libcares.a:
 	$(MAKE) -C $(LIBCARES_PATH) -f Makefile.m32
-
-


### PR DESCRIPTION
Due to missing [`-` markers](https://www.gnu.org/software/make/manual/make.html#Errors) in recipes, the library/dll (`lib`) build fails when running on a fresh source tree, because the target doesn't exist yet and trying to delete it results in a non-zero exit code. The marker is there in the tool build (`src`), so that works fine.