### PR TITLE
mingw build: allow to pass custom CFLAGS

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -55,7 +55,7 @@ LIBCARES_PATH = $(PROOT)/ares
 endif
 
 CC	= $(CROSSPREFIX)gcc
-CFLAGS	= -g -O2 -Wall
+CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS	= -s
@@ -323,5 +323,3 @@ $(PROOT)/include/curl/curlbuild.h:
 
 $(LIBCARES_PATH)/libcares.a:
 	$(MAKE) -C $(LIBCARES_PATH) -f Makefile.m32
-
-


### PR DESCRIPTION
Allow to pass custom `CFLAGS` options via environment variable `CURL_CFLAG_EXTRAS` (the name comes from `makefile.am` where it serves a similar purpose). Default and automatically added options of `makefile.m32` have preference over custom ones. This addition is useful for passing f.e. custom CPU tuning or LTO optimization (`-flto -ffat-lto-objects`) options. The only current way to do this is to edit `makefile.m32`. This patch makes it unnecessary.