### PR TITLE
sasl_sspi: Populate the domain from the realm in the challenge message i...

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -78,9 +78,6 @@ const struct {
 #define DIGEST_QOP_VALUE_STRING_AUTH_INT  "auth-int"
 #define DIGEST_QOP_VALUE_STRING_AUTH_CONF "auth-conf"
 
-#define DIGEST_MAX_VALUE_LENGTH           256
-#define DIGEST_MAX_CONTENT_LENGTH         1024
-
 /* The CURL_OUTPUT_DIGEST_CONV macro below is for non-ASCII machines.
    It converts digest text to ASCII so the MD5 will be correct for
    what ultimately goes over the network.
@@ -92,13 +89,16 @@ const struct {
     return result; \
   }
 
+#endif
+
+#if !defined(CURL_DISABLE_CRYPTO_AUTH)
 /*
  * Returns 0 on success and then the buffers are filled in fine.
  *
  * Non-zero means failure to parse.
  */
-static int sasl_digest_get_pair(const char *str, char *value, char *content,
-                                const char **endptr)
+int sasl_digest_get_pair(const char *str, char *value, char *content,
+                         const char **endptr)
 {
   int c;
   bool starts_with_quote = FALSE;
@@ -159,7 +159,9 @@ static int sasl_digest_get_pair(const char *str, char *value, char *content,
 
   return 0; /* all is fine! */
 }
+#endif
 
+#if !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(USE_WINDOWS_SSPI)
 /* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string*/
 static void sasl_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
                                      unsigned char *dest) /* 33 bytes */

--- a/lib/curl_sasl.h
+++ b/lib/curl_sasl.h
@@ -65,6 +65,11 @@ struct kerberos5data;
 #define SASL_MECH_STRING_NTLM       "NTLM"
 #define SASL_MECH_STRING_XOAUTH2    "XOAUTH2"
 
+#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#define DIGEST_MAX_VALUE_LENGTH           256
+#define DIGEST_MAX_CONTENT_LENGTH         1024
+#endif
+
 enum {
   CURLDIGESTALGO_MD5,
   CURLDIGESTALGO_MD5SESS
@@ -134,6 +139,12 @@ struct SASL {
 char *Curl_sasl_build_spn(const char *service, const char *instance);
 #else
 TCHAR *Curl_sasl_build_spn(const char *service, const char *instance);
+#endif
+
+#if defined(USE_WINDOWS_SSPI)
+/* This is used to extract the realm from a challenge message */
+int sasl_digest_get_pair(const char *str, char *value, char *content,
+	                     const char **endptr);
 #endif
 
 #if defined(HAVE_GSSAPI)

--- a/lib/curl_sasl_sspi.c
+++ b/lib/curl_sasl_sspi.c
@@ -40,6 +40,7 @@
 #include "curl_multibyte.h"
 #include "sendf.h"
 #include "strdup.h"
+#include "rawstr.h"
 
 #define _MPRINTF_REPLACE /* use our functions only */
 #include <curl/mprintf.h>
@@ -276,6 +277,75 @@ CURLcode Curl_sasl_create_digest_md5_message(struct SessionHandle *data,
 }
 
 /*
+* Curl_override_sspi_http_realm()
+*
+* This is used to populate a the domain in a SSPI identity structure
+* The realm is extracted from the challenge message and used as the
+* domain if it is not already explicitly set.
+*
+* Parameters:
+*
+* chlg     [in]     - The challenge message.
+* identity [in/out] - The identity structure.
+*
+* Returns CURLE_OK on success.
+*/
+CURLcode Curl_override_sspi_http_realm (const char *chlg,
+                                        SEC_WINNT_AUTH_IDENTITY *identity)
+{
+  xcharp_u domain, dup_domain;
+
+  /* If domain is blank or unset, check challenge message for realm */
+  if (!identity->Domain || !identity->DomainLength)
+  {
+    for (;;) {
+      char value[DIGEST_MAX_VALUE_LENGTH];
+      char content[DIGEST_MAX_CONTENT_LENGTH];
+
+      /* Pass all additional spaces here */
+      while (*chlg && ISSPACE(*chlg))
+        chlg++;
+
+      /* Extract a value=content pair */
+      if (!sasl_digest_get_pair(chlg, value, content, &chlg)) {
+        if (Curl_raw_equal(value, "realm")) {
+
+          /* Setup identity's domain and length */
+          domain.tchar_ptr = Curl_convert_UTF8_to_tchar((char *)content);
+          if (!domain.tchar_ptr)
+            return CURLE_OUT_OF_MEMORY;
+          dup_domain.tchar_ptr = _tcsdup(domain.tchar_ptr);
+          if (!dup_domain.tchar_ptr) {
+            Curl_unicodefree(domain.tchar_ptr);
+            return CURLE_OUT_OF_MEMORY;
+          }
+          identity->Domain = dup_domain.tbyte_ptr;
+          identity->DomainLength = curlx_uztoul(_tcslen(dup_domain.tchar_ptr));
+          dup_domain.tchar_ptr = NULL;
+
+          Curl_unicodefree(domain.tchar_ptr);
+        }
+        else {
+          /* unknown specifier, ignore it! */
+        }
+      }
+      else
+        break; /* we're done here */
+
+      /* Pass all additional spaces here */
+      while (*chlg && ISSPACE(*chlg))
+        chlg++;
+
+      /* Allow the list to be comma-separated */
+      if (',' == *chlg)
+        chlg++;
+    }
+  }
+
+  return CURLE_OK;
+}
+
+/*
  * Curl_sasl_decode_digest_http_message()
  *
  * This is used to decode a HTTP DIGEST challenge message into the seperate
@@ -373,7 +443,11 @@ CURLcode Curl_sasl_create_digest_http_message(struct SessionHandle *data,
 
   if(userp && *userp) {
     /* Populate our identity structure */
-    if(Curl_create_sspi_identity(userp, passwdp, &identity))
+    if (Curl_create_sspi_identity(userp, passwdp, &identity))
+      return CURLE_OUT_OF_MEMORY;
+
+    /* Populate our identity domain */
+    if (Curl_override_sspi_http_realm(digest->input_token, &identity))
       return CURLE_OUT_OF_MEMORY;
 
     /* Allow proper cleanup of the identity structure */


### PR DESCRIPTION
...f the user does not specify DOMAIN\User format

With the release of Curl 7.40.0, on Windows, SSPI handles http_digest authentication.

I've noticed that the behavior of using digest auth on most non-Microsoft based HTTP servers will return an unauthorized error. This is because the realm in the challenge response is not populated correctly. The only way to authorize access is for the user to have knowledge of the "Realm" of the challenge-message, which is not usually the case.

I've noticed the PHP Windows binaries now use 7.40.0 and compile with USE_WINDOWS_SSPI.

Some examples (user:password) formats specified with CURLOPT_USERPWD:
"User:Password" results in realm="", even though the server has specified a realm (this is NOT OK)
"Realm\User:Password" results in realm="Realm" (this is OK, maybe? Realm specified by the server may not be the same, but Microsoft HTTP servers may deal with this)

This also conflicts with users that may contain "\" and servers that don't use the MS DOMAIN\User format. Either way, the behavior significantly varies from using Curl without USE_WINDOWS_SSPI.

Instead, this patch populates the realm from the challenge message if the user does not explicitly use the DOMAIN\User format.

Example:
Domain\User ; domain=Domain, user=User
\Domain\User ; domain=server realm, user=Domain\User
User ; domain=server realm, user=User
Domain\ ; domain=Domain, user=blank
\ ; domain=server realm; user=blank
\\\ ; domain=server realm; user=\

