### PR TITLE
add link to Harbour bindings

### DIFF
--- a/docs/BINDINGS
+++ b/docs/BINDINGS
@@ -90,6 +90,11 @@ Guile:
   Written by Michael L. Gran
   http://www.lonelycactus.com/guile-curl.html
 
+Harbour
+
+  Written by Viktor SzakÃ¡ts
+  https://github.com/vszakats/harbour-core/tree/master/contrib/hbcurl
+
 Haskell
 
   Written by Galois, Inc
@@ -115,7 +120,7 @@ Lua
   luacurl by Alexander Marinov
   http://luacurl.luaforge.net/
 
-  Lua-cURL by Jürgen Hötzel
+  Lua-cURL by JÃ¼rgen HÃ¶tzel
   http://luaforge.net/projects/lua-curl/
 
 Mono
@@ -219,7 +224,7 @@ SPL
 
 Tcl
 
-  Tclcurl by Andrés García
+  Tclcurl by AndrÃ©s GarcÃ­a
   http://mirror.yellow5.com/tclcurl/
 
 Visual Basic


### PR DESCRIPTION
Non-ASCII characters were automatically updated by GitHub web-editor. They were in Windows-1250 codepage (making them appear wrongly in certain situations), now they must be in UTF-8, but I'll double check it. Please report back if this is undesired and there is a rule for codepages in curl docs to follow (I couldn't find it).

Note, the link to `hbcurl` is a fork of the mainline Harbour project, and this fork is where the component is regularly kept updated.