### PR TITLE
fixed libtest linker error on msvc

### DIFF
--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -39,9 +39,6 @@
 #define sleep(s) Sleep(s * 1000)
 #endif
 
-#define _MPRINTF_REPLACE
-#include <curl/mprintf.h>
-
 static int debug_callback(CURL *curl, curl_infotype info, char *msg, size_t len, void *ptr)
 {
   (void)curl;

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "test.h"
-
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 static const char *HOSTHEADER = "Host: www.host.foo.com";

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -26,9 +26,6 @@
  */
 
 #include "test.h"
-
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -28,8 +28,6 @@
 #include <fcntl.h>
 #endif
 
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 /* build request url */

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "test.h"
-
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 /* build request url */

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "test.h"
-
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 /* build request url */

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -37,8 +37,6 @@
 #  include <fcntl.h>
 #endif
 
-#include <curl/mprintf.h>
-
 #include "warnless.h"
 #include "memdebug.h"
 

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -28,8 +28,6 @@
 #include <fcntl.h>
 #endif
 
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 /* build request url */

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "test.h"
-
-#include <curl/mprintf.h>
-
 #include "memdebug.h"
 
 #define THREADS 2

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -40,6 +40,10 @@
 #  include "select.h"
 #endif
 
+#define _MPRINTF_REPLACE
+#include <curl/mprintf.h>
+
+
 #define test_setopt(A,B,C) \
   if((res = curl_easy_setopt((A),(B),(C))) != CURLE_OK) goto test_cleanup
 

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -21,10 +21,6 @@
  ***************************************************************************/
 
 #include "test.h"
-
-#define _MPRINTF_REPLACE /* use our functions only */
-#include <curl/mprintf.h>
-
 #include "testutil.h"
 #include "testtrace.h"
 #include "memdebug.h"
@@ -34,7 +30,7 @@ struct libtest_trace_cfg libtest_debug_config;
 static time_t epoch_offset; /* for test time tracing */
 static int    known_offset; /* for test time tracing */
 
-static 
+static
 void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
                         const unsigned char *ptr, size_t size, int nohex)
 {


### PR DESCRIPTION
The issue:

```
first.obj : error LNK2019: unresolved external symbol snprintf referenced in function hexdump [\curl\b\tests\libtest\lib526.vcxproj]
  C:\WORK\GITHUB\dev\curl\b\tests\libtest\Release\lib526.exe : fatal error LNK1120: 1 unresolved externals [\curl\b\tests\libtest\lib526.vcxproj]
```

How to reproduce:
```
cmake .. -G"Visual Studio 11 Win64"
cmake --build . --config Release
```

Suggested solution:
mprintf.h header added to test.h to prevent future issues in libtest