### PR TITLE
Fix include guards.

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURL_H
-#define __CURL_CURL_H
+#ifndef CURL_CURL_H
+#define CURL_CURL_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/curlbuild.h.cmake
+++ b/include/curl/curlbuild.h.cmake
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLBUILD_H
-#define __CURL_CURLBUILD_H
+#ifndef CURL_CURLBUILD_H
+#define CURL_CURLBUILD_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/curlbuild.h.dist
+++ b/include/curl/curlbuild.h.dist
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLBUILD_H
-#define __CURL_CURLBUILD_H
+#ifndef CURL_CURLBUILD_H
+#define CURL_CURLBUILD_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/curlbuild.h.in
+++ b/include/curl/curlbuild.h.in
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLBUILD_H
-#define __CURL_CURLBUILD_H
+#ifndef CURL_CURLBUILD_H
+#define CURL_CURLBUILD_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/curlrules.h
+++ b/include/curl/curlrules.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLRULES_H
-#define __CURL_CURLRULES_H
+#ifndef CURL_CURLRULES_H
+#define CURL_CURLRULES_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/curlver.h
+++ b/include/curl/curlver.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLVER_H
-#define __CURL_CURLVER_H
+#ifndef CURL_CURLVER_H
+#define CURL_CURLVER_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_EASY_H
-#define __CURL_EASY_H
+#ifndef CURL_EASY_H
+#define CURL_EASY_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_MPRINTF_H
-#define __CURL_MPRINTF_H
+#ifndef CURL_MPRINTF_H
+#define CURL_MPRINTF_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_MULTI_H
-#define __CURL_MULTI_H
+#ifndef CURL_MULTI_H
+#define CURL_MULTI_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_TYPECHECK_GCC_H
-#define __CURL_TYPECHECK_GCC_H
+#ifndef CURL_TYPECHECK_GCC_H
+#define CURL_TYPECHECK_GCC_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/packages/OS400/ccsidcurl.h
+++ b/packages/OS400/ccsidcurl.h
@@ -21,8 +21,8 @@
  *
  ***************************************************************************/
 
-#ifndef __CURL_CCSIDCURL_H
-#define __CURL_CCSIDCURL_H
+#ifndef CURL_CCSIDCURL_H
+#define CURL_CCSIDCURL_H
 
 #include "curl.h"
 #include "easy.h"

--- a/packages/vms/vms_eco_level.h
+++ b/packages/vms/vms_eco_level.h
@@ -22,8 +22,8 @@
 /* for a specific cURL x.y-z release. */
 /* When any part of x.y-z is incremented, the ECO should be set back to 0 */
 
-#ifndef _VMS_ECO_LEVEL_H
-#define _VMS_ECO_LEVEL_H
+#ifndef VMS_ECO_LEVEL_H
+#define VMS_ECO_LEVEL_H
 
 #define VMS_ECO_LEVEL "0"
 


### PR DESCRIPTION
Some include guards did not fit to [the expected naming convention of the C language standard](https://www.securecoding.cert.org/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier "Do not use identifiers that are reserved for the compiler implementation.").

This implementation detail can be fixed by deletion of [a few underscores](http://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier#answer-228797 "What are the rules about using an underscore in a C++ identifier?").