### PR TITLE
tool: Improve deducing remote name from URL

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -1157,8 +1157,9 @@ Consequentially, the file will be saved in the current working directory. If
 you want the file saved in a different directory, make sure you change current
 working directory before you invoke curl with the \fB-O, --remote-name\fP flag!
 
-There is no URL decoding done on the file name. If it has %20 or other URL
-encoded parts of the name, they will end up as-is as file name.
+The file name will be URL-decoded. Anything to the left of encoded path
+separators will be stripped, and an error will be returned if the URL contains
+any control characters, %00 - %1F.
 
 You may use this option as many times as the number of URLs you have.
 .IP "--oauth2-bearer"

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -138,7 +138,7 @@ test1364 test1365 test1366 test1367 test1368 test1369 test1370 test1371 \
 test1372 test1373 test1374 test1375 test1376 test1377 test1378 test1379 \
 test1380 test1381 test1382 test1383 test1384 test1385 test1386 test1387 \
 test1388 test1389 test1390 test1391 test1392 test1393 test1394 test1395 \
-test1396 test1397 test1398 \
+test1396 test1397 test1398 test1399 \
 \
 test1400 test1401 test1402 test1403 test1404 test1405 test1406 test1407 \
 test1408 test1409 test1410 test1411 test1412 test1413 test1414 test1415 \

--- a/tests/data/test1399
+++ b/tests/data/test1399
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+get_url_file_name
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+get_url_file_name unit tests
+ </name>
+<tool>
+unit1399
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -7,7 +7,7 @@ UNITFILES = curlcheck.h \
 # These are all unit test programs
 UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307	\
  unit1308 unit1309 unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
- unit1600 unit1601
+ unit1399 unit1600 unit1601
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -56,6 +56,9 @@ unit1397_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1398_SOURCES = unit1398.c $(UNITFILES)
 unit1398_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1399_SOURCES = unit1399.c $(UNITFILES)
+unit1399_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1600_SOURCES = unit1600.c $(UNITFILES)
 unit1600_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "tool_operhlp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "memdebug.h" /* LAST include file */
+
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+
+}
+
+UNITTEST_START
+
+  const char *values[] = {
+    "http://example.com",                                     "",
+    "http://example.com/",                                    "",
+    "http://example.com/hello.jpg",                           "hello.jpg",
+    "ftp://example.com/hello.jpg",                            "hello.jpg",
+    "http://example.com/hello.jpg?stuff=things",              "hello.jpg",
+    "http://example.com/hello.jpg#section1",                  "hello.jpg",
+    "http://example.com/hello.jpg?stuff=things#section1",     "hello.jpg",
+    "http://example.com/hello%3Fthere.jpg",                   "hello?there.jpg",
+    "http://example.com/hello%00there.jpg",                   NULL,
+    "http://example.com/hello%1Fthere.jpg",                   NULL,
+    "http://example.com/hello%23there.jpg",                   "hello#there.jpg",
+    "http://example.com/asdf/hello.jpg",                      "hello.jpg",
+    "http://example.com/hello%20there.jpg",                   "hello there.jpg",
+    "http://example.com/hello%20there.jpg?a=b",               "hello there.jpg",
+    "http://example.com/hello%20there.jpg#s1",                "hello there.jpg",
+    "http://example.com/..%2F..%2Fetc%2Fhello.jpg",           "hello.jpg",
+    "http://example.com/..%5CWindows%5CSystem32%5Chello.jpg", "hello.jpg",
+    "http://example.com/..%5Cdir1%2Fhello.jpg",               "hello.jpg",
+    "http://example.com/..%2Fdir1%5Chello.jpg",               "hello.jpg",
+    NULL,                                                     NULL,
+  };
+
+  const char **p;
+  const char *url, *expected_fn;
+  char *actual_fn;
+  CURLcode res;
+
+  for(p = values; *p; p += 2) {
+    url = p[0];
+    expected_fn = p[1];
+
+    res = get_url_file_name(&actual_fn, url);
+    if(res != CURLE_OK) {
+      if(expected_fn != NULL) {
+        printf("get_url_file_name != CURLE_OK for url '%s': %s\n", url,
+            curl_easy_strerror(res));
+        fail("get_url_file_name not CURLE_OK");
+      }
+      continue;
+    }
+
+    if(strcmp(expected_fn, actual_fn) != 0) {
+      printf("expected filename '%s' from url '%s' but got '%s'\n",
+          expected_fn, url, actual_fn);
+      fail("assertion failed");
+    }
+
+    Curl_safefree(actual_fn);
+  }
+
+UNITTEST_STOP


### PR DESCRIPTION
Before this, when using the tool's `-O`/`--remote-name`, the query
string would be included in the filename and it wouldn't be URL-escaped.
Anything to the left of path seperators is stripped. Control characters
raise an error. Encoding is left unaddressed. In Unix, filenames
encoding is not defined, so that seems reasonable. Windows/NTFS uses
UTF-16, but as we don't know the input encoding (although UTF-8 seems to
be being standardised around) any conversion would be a guess.

I've tried to follow all the docs/style guides/etc that I can see, but I'm new
to the project and not immensely seasoned in C, so apologies if I've messed
something up!