### PR TITLE
.travis.yml: Change CI make test to make test-full

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: c
 before_script:
   - ./buildconf
 
+script: ./configure --enable-debug && make && make test-full
+
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
I don't have a way to be sure about this change until it's processed by the CI. I ran it through [Travis' config checker](http://lint.travis-ci.org/) and it passes.

The purpose of this change is so that runtests.pl will run with the `-p` flag so that it will print all log output to stdout when a test fails. As it stands right now when a test fails I cannot see why, only that it failed. If there is a way the log files are accessible from Travis I can't find it. Assuming there isn't I think a solution is to dump the files to stdout so that we will be able to see them in Travis' job log output when a build fails.

commit message:

Change the continuous integration script to use 'make test-full' instead
of just 'make test' so that the diagnostic log output is printed to
stdout when a test fails.

Prior to this change Travis used its default C test script:
./configure && make && make test
