### PR TITLE
Delete unnecessary checks before some function calls

### DIFF
--- a/docs/examples/fopen.c
+++ b/docs/examples/fopen.c
@@ -210,9 +210,7 @@ static int use_buffer(URL_FILE *file,int want)
   /* sort out buffer */
   if((file->buffer_pos - want) <=0) {
     /* ditch buffer - write will recreate */
-    if(file->buffer)
-      free(file->buffer);
-
+    free(file->buffer);
     file->buffer=NULL;
     file->buffer_pos=0;
     file->buffer_len=0;
@@ -302,9 +300,7 @@ int url_fclose(URL_FILE *file)
     break;
   }
 
-  if(file->buffer)
-    free(file->buffer);/* free any allocated buffer space */
-
+  free(file->buffer);/* free any allocated buffer space */
   free(file);
 
   return ret;
@@ -435,9 +431,7 @@ void url_rewind(URL_FILE *file)
     curl_multi_add_handle(multi_handle, file->handle.curl);
 
     /* ditch buffer - write will recreate - resets stream pos*/
-    if(file->buffer)
-      free(file->buffer);
-
+    free(file->buffer);
     file->buffer=NULL;
     file->buffer_pos=0;
     file->buffer_len=0;

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -106,8 +106,7 @@ int main(void)
   /* cleanup curl stuff */
   curl_easy_cleanup(curl_handle);
 
-  if(chunk.memory)
-    free(chunk.memory);
+  free(chunk.memory);
 
   /* we're done with libcurl, so clean it up */
   curl_global_cleanup();

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -101,8 +101,7 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
 
-    if(chunk.memory)
-      free(chunk.memory);
+    free(chunk.memory);
 
     /* we're done with libcurl, so clean it up */
     curl_global_cleanup();

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -186,8 +186,7 @@ void Curl_resolver_cancel(struct connectdata *conn)
  */
 static void destroy_async_data (struct Curl_async *async)
 {
-  if(async->hostname)
-    free(async->hostname);
+  free(async->hostname);
 
   if(async->os_specific) {
     struct ResolverResults *res = (struct ResolverResults *)async->os_specific;

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -190,8 +190,7 @@ void destroy_thread_sync_data(struct thread_sync_data * tsd)
     free(tsd->mtx);
   }
 
-  if(tsd->hostname)
-    free(tsd->hostname);
+  free(tsd->hostname);
 
   if(tsd->res)
     Curl_freeaddrinfo(tsd->res);
@@ -364,9 +363,7 @@ static void destroy_async_data (struct Curl_async *async)
   }
   async->os_specific = NULL;
 
-  if(async->hostname)
-    free(async->hostname);
-
+  free(async->hostname);
   async->hostname = NULL;
 }
 

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -252,8 +252,7 @@ static CURLcode base64_encode(const char *table64,
   *output = '\0';
   *outptr = base64data; /* return pointer to new data, allocated memory */
 
-  if(convbuf)
-    free(convbuf);
+  free(convbuf);
 
   *outlen = strlen(base64data); /* return the length of the new data */
 

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -103,23 +103,14 @@ Example set of cookies:
 
 static void freecookie(struct Cookie *co)
 {
-  if(co->expirestr)
-    free(co->expirestr);
-  if(co->domain)
-    free(co->domain);
-  if(co->path)
-    free(co->path);
-  if(co->spath)
-    free(co->spath);
-  if(co->name)
-    free(co->name);
-  if(co->value)
-    free(co->value);
-  if(co->maxage)
-    free(co->maxage);
-  if(co->version)
-    free(co->version);
-
+  free(co->expirestr);
+  free(co->domain);
+  free(co->path);
+  free(co->spath);
+  free(co->name);
+  free(co->value);
+  free(co->maxage);
+  free(co->version);
   free(co);
 }
 
@@ -296,8 +287,7 @@ void Curl_cookie_loadfiles(struct SessionHandle *data)
  */
 static void strstore(char **str, const char *newstr)
 {
-  if(*str)
-    free(*str);
+  free(*str);
   *str = strdup(newstr);
 }
 
@@ -832,21 +822,13 @@ Curl_cookie_add(struct SessionHandle *data,
 
         /* then free all the old pointers */
         free(clist->name);
-        if(clist->value)
-          free(clist->value);
-        if(clist->domain)
-          free(clist->domain);
-        if(clist->path)
-          free(clist->path);
-        if(clist->spath)
-          free(clist->spath);
-        if(clist->expirestr)
-          free(clist->expirestr);
-
-        if(clist->version)
-          free(clist->version);
-        if(clist->maxage)
-          free(clist->maxage);
+        free(clist->value);
+        free(clist->domain);
+        free(clist->path);
+        free(clist->spath);
+        free(clist->expirestr);
+        free(clist->version);
+        free(clist->maxage);
 
         *clist = *co;  /* then store all the new data */
 
@@ -1214,8 +1196,7 @@ void Curl_cookie_clearsess(struct CookieInfo *cookies)
 void Curl_cookie_cleanup(struct CookieInfo *c)
 {
   if(c) {
-    if(c->filename)
-      free(c->filename);
+    free(c->filename);
     Curl_cookie_freelist(c->cookies, TRUE);
     free(c); /* free the base struct as well */
   }

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -80,13 +80,8 @@ Curl_freeaddrinfo(Curl_addrinfo *cahead)
   Curl_addrinfo *ca;
 
   for(ca = cahead; ca != NULL; ca = canext) {
-
-    if(ca->ai_addr)
-      free(ca->ai_addr);
-
-    if(ca->ai_canonname)
-      free(ca->ai_canonname);
-
+    free(ca->ai_addr);
+    free(ca->ai_canonname);
     canext = ca->ai_next;
 
     free(ca);

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -419,10 +419,8 @@ CURLcode Curl_output_ntlm_wb(struct connectdata *conn,
   case NTLMSTATE_TYPE3:
     /* connection is already authenticated,
      * don't send a header in future requests */
-    if(*allocuserpwd) {
-      free(*allocuserpwd);
-      *allocuserpwd=NULL;
-    }
+    free(*allocuserpwd);
+    *allocuserpwd=NULL;
     authp->done = TRUE;
     break;
   }

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -227,6 +227,5 @@ char *curl_easy_unescape(CURL *handle, const char *string, int length,
    the library's memory system */
 void curl_free(void *p)
 {
-  if(p)
-    free(p);
+  free(p);
 }

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -972,16 +972,14 @@ void curl_formfree(struct curl_httppost *form)
     if(form->more)
       curl_formfree(form->more);
 
-    if(!(form->flags & HTTPPOST_PTRNAME) && form->name)
+    if(!(form->flags & HTTPPOST_PTRNAME))
       free(form->name); /* free the name */
     if(!(form->flags &
-         (HTTPPOST_PTRCONTENTS|HTTPPOST_BUFFER|HTTPPOST_CALLBACK)) &&
-       form->contents)
+         (HTTPPOST_PTRCONTENTS|HTTPPOST_BUFFER|HTTPPOST_CALLBACK))
+      )
       free(form->contents); /* free the contents */
-    if(form->contenttype)
-      free(form->contenttype); /* free the content type */
-    if(form->showfilename)
-      free(form->showfilename); /* free the faked file name */
+    free(form->contenttype); /* free the content type */
+    free(form->showfilename); /* free the faked file name */
     free(form);       /* free the struct */
 
   } while((form = next) != NULL); /* continue */

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -969,8 +969,7 @@ void curl_formfree(struct curl_httppost *form)
     next=form->next;  /* the following form line */
 
     /* recurse to sub-contents */
-    if(form->more)
-      curl_formfree(form->more);
+    curl_formfree(form->more);
 
     if(!(form->flags & HTTPPOST_PTRNAME))
       free(form->name); /* free the name */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -283,10 +283,8 @@ static void freedirs(struct ftp_conn *ftpc)
   int i;
   if(ftpc->dirs) {
     for(i=0; i < ftpc->dirdepth; i++) {
-      if(ftpc->dirs[i]) {
-        free(ftpc->dirs[i]);
-        ftpc->dirs[i]=NULL;
-      }
+      free(ftpc->dirs[i]);
+      ftpc->dirs[i]=NULL;
     }
     free(ftpc->dirs);
     ftpc->dirs = NULL;
@@ -1523,16 +1521,13 @@ static CURLcode ftp_state_list(struct connectdata *conn)
                  lstArg? lstArg: "" );
 
   if(!cmd) {
-    if(lstArg)
-      free(lstArg);
+    free(lstArg);
     return CURLE_OUT_OF_MEMORY;
   }
 
   result = Curl_pp_sendf(&conn->proto.ftpc.pp, "%s", cmd);
 
-  if(lstArg)
-    free(lstArg);
-
+  free(lstArg);
   free(cmd);
 
   if(result)
@@ -3266,8 +3261,7 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
   }
 
   /* now store a copy of the directory we are in */
-  if(ftpc->prevpath)
-    free(ftpc->prevpath);
+  free(ftpc->prevpath);
 
   if(data->set.wildcardmatch) {
     if(data->set.chunk_end && ftpc->file) {
@@ -4192,14 +4186,10 @@ static CURLcode ftp_disconnect(struct connectdata *conn, bool dead_connection)
   }
 
   freedirs(ftpc);
-  if(ftpc->prevpath) {
-    free(ftpc->prevpath);
-    ftpc->prevpath = NULL;
-  }
-  if(ftpc->server_os) {
-    free(ftpc->server_os);
-    ftpc->server_os = NULL;
-  }
+  free(ftpc->prevpath);
+  ftpc->prevpath = NULL;
+  free(ftpc->server_os);
+  ftpc->server_os = NULL;
 
   Curl_pp_disconnect(pp);
 

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -187,8 +187,7 @@ struct ftp_parselist_data *Curl_ftp_parselist_data_alloc(void)
 
 void Curl_ftp_parselist_data_free(struct ftp_parselist_data **pl_data)
 {
-  if(*pl_data)
-    free(*pl_data);
+  free(*pl_data);
   *pl_data = NULL;
 }
 

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -58,8 +58,7 @@ CURLcode Curl_initinfo(struct SessionHandle *data)
   info->filetime = -1; /* -1 is an illegal time and thus means unknown */
   info->timecond = FALSE;
 
-  if(info->contenttype)
-    free(info->contenttype);
+  free(info->contenttype);
   info->contenttype = NULL;
 
   info->header_size = 0;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1124,8 +1124,7 @@ CURLcode Curl_add_buffer_send(Curl_send_buffer *in,
   /* Curl_convert_to_network calls failf if unsuccessful */
   if(result) {
     /* conversion failed, free memory and return to the caller */
-    if(in->buffer)
-      free(in->buffer);
+    free(in->buffer);
     free(in);
     return result;
   }
@@ -1228,8 +1227,7 @@ CURLcode Curl_add_buffer_send(Curl_send_buffer *in,
         conn->writechannel_inuse = FALSE;
     }
   }
-  if(in->buffer)
-    free(in->buffer);
+  free(in->buffer);
   free(in);
 
   return result;
@@ -1253,8 +1251,7 @@ CURLcode Curl_add_bufferf(Curl_send_buffer *in, const char *fmt, ...)
     return result;
   }
   /* If we failed, we cleanup the whole buffer and return error */
-  if(in->buffer)
-    free(in->buffer);
+  free(in->buffer);
   free(in);
   return CURLE_OUT_OF_MEMORY;
 }
@@ -1826,10 +1823,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   http = data->req.protop;
 
   if(!data->state.this_is_a_follow) {
-    /* this is not a followed location, get the original host name */
-    if(data->state.first_host)
-      /* Free to avoid leaking memory on multiple requests*/
-      free(data->state.first_host);
+    /* Free to avoid leaking memory on multiple requests*/
+    free(data->state.first_host);
 
     data->state.first_host = strdup(conn->host.name);
     if(!data->state.first_host)
@@ -1873,7 +1868,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
      it might have been used in the proxy connect, but if we have got a header
      with the user-agent string specified, we erase the previously made string
      here. */
-  if(Curl_checkheaders(conn, "User-Agent:") && conn->allocptr.uagent) {
+  if(Curl_checkheaders(conn, "User-Agent:")) {
     free(conn->allocptr.uagent);
     conn->allocptr.uagent=NULL;
   }
@@ -2211,8 +2206,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
     if(((httpreq == HTTPREQ_GET) || (httpreq == HTTPREQ_HEAD)) &&
        !Curl_checkheaders(conn, "Range:")) {
       /* if a line like this was already allocated, free the previous one */
-      if(conn->allocptr.rangeline)
-        free(conn->allocptr.rangeline);
+      free(conn->allocptr.rangeline);
       conn->allocptr.rangeline = aprintf("Range: bytes=%s\r\n",
                                          data->state.range);
     }
@@ -2220,8 +2214,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
             !Curl_checkheaders(conn, "Content-Range:")) {
 
       /* if a line like this was already allocated, free the previous one */
-      if(conn->allocptr.rangeline)
-        free(conn->allocptr.rangeline);
+      free(conn->allocptr.rangeline);
 
       if(data->set.set_resume_from < 0) {
         /* Upload resume was asked for, but we don't know the size of the

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -121,13 +121,11 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       infof(data, "Establish HTTP proxy tunnel to %s:%hu\n",
             hostname, remote_port);
 
-      if(data->req.newurl) {
         /* This only happens if we've looped here due to authentication
            reasons, and we don't really use the newly cloned URL here
            then. Just free() it. */
-        free(data->req.newurl);
-        data->req.newurl = NULL;
-      }
+      free(data->req.newurl);
+      data->req.newurl = NULL;
 
       /* initialize a dynamic send-buffer */
       req_buffer = Curl_add_buffer_init();
@@ -552,11 +550,8 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       infof(data, "Connect me again please\n");
     }
     else {
-      if(data->req.newurl) {
-        /* this won't be used anymore for the CONNECT so free it now */
-        free(data->req.newurl);
-        data->req.newurl = NULL;
-      }
+      free(data->req.newurl);
+      data->req.newurl = NULL;
       /* failure, close this connection to avoid re-use */
       connclose(conn, "proxy CONNECT failure");
       Curl_closesocket(conn, conn->sock[sockindex]);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -996,11 +996,8 @@ static void _ldap_free_urldesc (LDAPURLDesc *ludp)
   if(!ludp)
     return;
 
-  if(ludp->lud_dn)
-    free(ludp->lud_dn);
-
-  if(ludp->lud_filter)
-    free(ludp->lud_filter);
+  free(ludp->lud_dn);
+  free(ludp->lud_filter);
 
   if(ludp->lud_attrs) {
     for(i = 0; i < ludp->lud_attrs_dups; i++)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -217,8 +217,7 @@ static void sh_freeentry(void *freethis)
 {
   struct Curl_sh_entry *p = (struct Curl_sh_entry *) freethis;
 
-  if(p)
-    free(p);
+  free(p);
 }
 
 static size_t fd_key_compare(void *k1, size_t k1_len, void *k2, size_t k2_len)
@@ -1582,8 +1581,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           if(!retry) {
             /* if the URL is a follow-location and not just a retried request
                then figure out the URL here */
-            if(newurl)
-              free(newurl);
+            free(newurl);
             newurl = data->req.newurl;
             data->req.newurl = NULL;
             follow = FOLLOW_REDIR;
@@ -1608,8 +1606,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           /* but first check to see if we got a location info even though we're
              not following redirects */
           if(data->req.location) {
-            if(newurl)
-              free(newurl);
+            free(newurl);
             newurl = data->req.location;
             data->req.location = NULL;
             result = Curl_follow(data, newurl, FOLLOW_FAKE);
@@ -1624,8 +1621,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         }
       }
 
-      if(newurl)
-        free(newurl);
+      free(newurl);
       break;
     }
 

--- a/lib/nwlib.c
+++ b/lib/nwlib.c
@@ -282,9 +282,7 @@ int DisposeLibraryData( void *data )
   if(data) {
     void *tenbytes = ((libdata_t *) data)->tenbytes;
 
-    if(tenbytes)
-      free(tenbytes);
-
+    free(tenbytes);
     free(data);
   }
 
@@ -296,9 +294,7 @@ void DisposeThreadData( void *data )
   if(data) {
     void *twentybytes = ((libthreaddata_t *) data)->twentybytes;
 
-    if(twentybytes)
-      free(twentybytes);
-
+    free(twentybytes);
     free(data);
   }
 }

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -493,10 +493,8 @@ CURLcode Curl_pp_flushsend(struct pingpong *pp)
 
 CURLcode Curl_pp_disconnect(struct pingpong *pp)
 {
-  if(pp->cache) {
-    free(pp->cache);
-    pp->cache = NULL;
-  }
+  free(pp->cache);
+  pp->cache = NULL;
   return CURLE_OK;
 }
 

--- a/lib/security.c
+++ b/lib/security.c
@@ -577,10 +577,8 @@ Curl_sec_end(struct connectdata *conn)
 {
   if(conn->mech != NULL && conn->mech->end)
     conn->mech->end(conn->app_data);
-  if(conn->app_data) {
-    free(conn->app_data);
-    conn->app_data = NULL;
-  }
+  free(conn->app_data);
+  conn->app_data = NULL;
   if(conn->in_buffer.data) {
     free(conn->in_buffer.data);
     conn->in_buffer.data = NULL;

--- a/lib/share.c
+++ b/lib/share.c
@@ -198,8 +198,7 @@ curl_share_cleanup(CURLSH *sh)
   }
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
-  if(share->cookies)
-    Curl_cookie_cleanup(share->cookies);
+  Curl_cookie_cleanup(share->cookies);
 #endif
 
 #ifdef USE_SSL

--- a/lib/url.c
+++ b/lib/url.c
@@ -448,10 +448,8 @@ CURLcode Curl_close(struct SessionHandle *data)
   Curl_ssl_free_certinfo(data);
 
   /* Cleanup possible redirect junk */
-  if(data->req.newurl) {
-    free(data->req.newurl);
-    data->req.newurl = NULL;
-  }
+  free(data->req.newurl);
+  data->req.newurl = NULL;
 
   if(data->change.referer_alloc) {
     Curl_safefree(data->change.referer);
@@ -668,8 +666,7 @@ CURLcode Curl_open(struct SessionHandle **curl)
 
   if(result) {
     Curl_resolver_cleanup(data->state.resolver);
-    if(data->state.headerbuff)
-      free(data->state.headerbuff);
+    free(data->state.headerbuff);
     Curl_freeset(data);
     free(data);
     data = NULL;
@@ -2731,10 +2728,9 @@ CURLcode Curl_disconnect(struct connectdata *conn, bool dead_connection)
   free(conn->host.encalloc); /* encoded host name buffer, must be freed with
                                 idn_free() since this was allocated by
                                 curl_win32_idn_to_ascii */
-  if(conn->proxy.encalloc)
-    free(conn->proxy.encalloc); /* encoded proxy name buffer, must be freed
-                                   with idn_free() since this was allocated by
-                                   curl_win32_idn_to_ascii */
+  free(conn->proxy.encalloc); /* encoded proxy name buffer, must be freed
+                                 with idn_free() since this was allocated by
+                                 curl_win32_idn_to_ascii */
 #endif
 
   Curl_ssl_close(conn, FIRSTSOCKET);
@@ -4425,8 +4421,7 @@ static char *detect_proxy(struct connectdata *conn)
     }
   } /* if(!check_noproxy(conn->host.name, no_proxy)) - it wasn't specified
        non-proxy */
-  if(no_proxy)
-    free(no_proxy);
+  free(no_proxy);
 
 #else /* !CURL_DISABLE_HTTP */
 
@@ -5189,8 +5184,7 @@ static CURLcode resolve_server(struct SessionHandle *data,
 static void reuse_conn(struct connectdata *old_conn,
                        struct connectdata *conn)
 {
-  if(old_conn->proxy.rawalloc)
-    free(old_conn->proxy.rawalloc);
+  free(old_conn->proxy.rawalloc);
 
   /* free the SSL config struct from this connection struct as this was
      allocated in vain and is targeted for destruction */
@@ -5439,10 +5433,8 @@ static CURLcode create_conn(struct SessionHandle *data,
 
   if(data->set.str[STRING_NOPROXY] &&
      check_noproxy(conn->host.name, data->set.str[STRING_NOPROXY])) {
-    if(proxy) {
-      free(proxy);  /* proxy is in exception list */
-      proxy = NULL;
-    }
+    free(proxy);  /* proxy is in exception list */
+    proxy = NULL;
   }
   else if(!proxy)
     proxy = detect_proxy(conn);
@@ -5931,14 +5923,10 @@ CURLcode Curl_done(struct connectdata **connp,
   conn->bits.done = TRUE; /* called just now! */
 
   /* Cleanup possible redirect junk */
-  if(data->req.newurl) {
-    free(data->req.newurl);
-    data->req.newurl = NULL;
-  }
-  if(data->req.location) {
-    free(data->req.location);
-    data->req.location = NULL;
-  }
+  free(data->req.newurl);
+  data->req.newurl = NULL;
+  free(data->req.location);
+  data->req.location = NULL;
 
   Curl_resolver_cancel(conn);
 
@@ -5971,10 +5959,8 @@ CURLcode Curl_done(struct connectdata **connp,
 
   /* if the transfer was completed in a paused state there can be buffered
      data left to write and then kill */
-  if(data->state.tempwrite) {
-    free(data->state.tempwrite);
-    data->state.tempwrite = NULL;
-  }
+  free(data->state.tempwrite);
+  data->state.tempwrite = NULL;
 
   /* if data->set.reuse_forbid is TRUE, it means the libcurl client has
      forced us to close this connection. This is ignored for requests taking

--- a/lib/url.c
+++ b/lib/url.c
@@ -2150,8 +2150,7 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
       if(data->share->cookies) {
         /* use shared cookie list, first free own one if any */
-        if(data->cookies)
-          Curl_cookie_cleanup(data->cookies);
+        Curl_cookie_cleanup(data->cookies);
         /* enable cookies since we now use a share that uses cookies! */
         data->cookies = data->share->cookies;
       }

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1245,10 +1245,8 @@ void Curl_nss_close(struct connectdata *conn, int sockindex)
        * authentication data from a previous connection. */
       SSL_InvalidateSession(connssl->handle);
 
-    if(connssl->client_nickname != NULL) {
-      free(connssl->client_nickname);
-      connssl->client_nickname = NULL;
-    }
+    free(connssl->client_nickname);
+    connssl->client_nickname = NULL;
     /* destroy all NSS objects in order to avoid failure of NSS shutdown */
     Curl_llist_destroy(connssl->obj_list, NULL);
     connssl->obj_list = NULL;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -463,9 +463,8 @@ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
   store->sessionid = ssl_sessionid;
   store->idsize = idsize;
   store->age = *general_age;    /* set current age */
-  if(store->name)
     /* free it if there's one already present */
-    free(store->name);
+  free(store->name);
   store->name = clone_host;               /* clone host name */
   store->remote_port = conn->remote_port; /* port number */
 

--- a/lib/wildcard.c
+++ b/lib/wildcard.c
@@ -59,15 +59,10 @@ void Curl_wildcard_dtor(struct WildcardData *wc)
     wc->filelist = NULL;
   }
 
-  if(wc->path) {
-    free(wc->path);
-    wc->path = NULL;
-  }
-
-  if(wc->pattern) {
-    free(wc->pattern);
-    wc->pattern = NULL;
-  }
+  free(wc->path);
+  wc->path = NULL;
+  free(wc->pattern);
+  wc->pattern = NULL;
 
   wc->customptr = NULL;
   wc->state = CURLWC_INIT;

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -1116,8 +1116,7 @@ CURLcode Curl_verifyhost(struct connectdata * conn,
           if(len > 0)
             if(strlen(dnsname) == (size_t) len)
               i = Curl_cert_hostcheck((const char *) dnsname, conn->host.name);
-          if(dnsname)
-            free(dnsname);
+          free(dnsname);
           if(!i)
             return CURLE_PEER_FAILED_VERIFICATION;
           matched = i;

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1193,10 +1193,7 @@ curl_easy_setopt_ccsid(CURL * curl, CURLoption tag, ...)
       }
 
     result = curl_easy_setopt(curl, tag, s);
-
-    if(s)
-      free(s);
-
+    free(s);
     break;
 
   case CURLOPT_COPYPOSTFIELDS:

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -99,9 +99,7 @@ thdbufdestroy(void * private)
     localkey_t i;
 
     for(i = (localkey_t) 0; i < LK_LAST; i++) {
-      if(p->buf)
-        free(p->buf);
-
+      free(p->buf);
       p++;
       }
 
@@ -281,9 +279,7 @@ Curl_getnameinfo_a(const struct sockaddr * sa, curl_socklen_t salen,
 
   if(servname && servnamelen)
     if(!(eservname = malloc(servnamelen))) {
-      if(enodename)
-        free(enodename);
-
+      free(enodename);
       return EAI_MEMORY;
       }
 
@@ -304,12 +300,8 @@ Curl_getnameinfo_a(const struct sockaddr * sa, curl_socklen_t salen,
       }
     }
 
-  if(enodename)
-    free(enodename);
-
-  if(eservname)
-    free(eservname);
-
+  free(enodename);
+  free(eservname);
   return status;
 }
 
@@ -342,9 +334,7 @@ Curl_getaddrinfo_a(const char * nodename, const char * servname,
     i = strlen(servname);
 
     if(!(eservname = malloc(i + 1))) {
-      if(enodename)
-        free(enodename);
-
+      free(enodename);
       return EAI_MEMORY;
       }
 
@@ -353,13 +343,8 @@ Curl_getaddrinfo_a(const char * nodename, const char * servname,
     }
 
   status = getaddrinfo(enodename, eservname, hints, res);
-
-  if(enodename)
-    free(enodename);
-
-  if(eservname)
-    free(eservname);
-
+  free(enodename);
+  free(eservname);
   return status;
 }
 
@@ -886,9 +871,7 @@ Curl_gss_init_sec_context_a(OM_uint32 * minor_status,
                              target_name, mech_type, req_flags, time_req,
                              input_chan_bindings, inp, actual_mech_type,
                              output_token, ret_flags, time_rec);
-
-  if(in.value)
-    free(in.value);
+  free(in.value);
 
   if(rc != GSS_S_COMPLETE || !output_token ||
       !output_token->length || !output_token->value)
@@ -985,9 +968,7 @@ Curl_ldap_simple_bind_s_a(void * ld, char * dn, char * passwd)
     i = strlen(passwd);
 
     if(!(epasswd = malloc(i + 1))) {
-      if(edn)
-        free(edn);
-
+      free(edn);
       return LDAP_NO_MEMORY;
       }
 
@@ -996,13 +977,8 @@ Curl_ldap_simple_bind_s_a(void * ld, char * dn, char * passwd)
     }
 
   i = ldap_simple_bind_s(ld, edn, epasswd);
-
-  if(epasswd)
-    free(epasswd);
-
-  if(edn)
-    free(edn);
-
+  free(epasswd);
+  free(edn);
   return i;
 }
 
@@ -1079,12 +1055,8 @@ Curl_ldap_search_s_a(void * ld, char * base, int scope, char * filter,
     free(eattrs);
     }
 
-  if(efilter)
-    free(efilter);
-
-  if(ebase)
-    free(ebase);
-
+  free(efilter);
+  free(ebase);
   return status;
 }
 
@@ -1112,9 +1084,7 @@ Curl_ldap_get_values_len_a(void * ld, LDAPMessage * entry, const char * attr)
     }
 
   result = ldap_get_values_len(ld, entry, cp);
-
-  if(cp)
-    free(cp);
+  free(cp);
 
   /* Result data are binary in nature, so they haven't been
      converted to EBCDIC. Therefore do not convert. */

--- a/tests/libtest/lib539.c
+++ b/tests/libtest/lib539.c
@@ -83,8 +83,7 @@ int test(char *URL)
 test_cleanup:
 
    curl_slist_free_all(slist);
-   if(newURL)
-     free(newURL);
+   free(newURL);
    curl_easy_cleanup(curl);
    curl_global_cleanup();
 

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -159,8 +159,7 @@ test_cleanup:
   if(sdpf)
     fclose(sdpf);
 
-  if(stream_uri)
-    free(stream_uri);
+  free(stream_uri);
 
   if(custom_headers)
     curl_slist_free_all(custom_headers);

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -115,9 +115,7 @@ test_cleanup:
   if(idfile)
     fclose(idfile);
 
-  if(stream_uri)
-    free(stream_uri);
-
+  free(stream_uri);
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -102,9 +102,7 @@ int test(char *URL)
   }
 
 test_cleanup:
-
-  if(stream_uri)
-    free(stream_uri);
+  free(stream_uri);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -195,9 +195,7 @@ int test(char *URL)
   }
 
 test_cleanup:
-
-  if(stream_uri)
-    free(stream_uri);
+  free(stream_uri);
 
   if(protofile)
     fclose(protofile);

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -165,8 +165,7 @@ test_cleanup:
   if(paramsf)
     fclose(paramsf);
 
-  if(stream_uri)
-    free(stream_uri);
+  free(stream_uri);
 
   if(custom_headers)
     curl_slist_free_all(custom_headers);

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -357,10 +357,8 @@ test_cleanup:
   fclose(hd_src);
 
   /* free local memory */
-  if(sockets.read.sockets)
-    free(sockets.read.sockets);
-  if(sockets.write.sockets)
-    free(sockets.write.sockets);
+  free(sockets.read.sockets);
+  free(sockets.write.sockets);
 
   return res;
 }

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -209,8 +209,7 @@ static int decodedata(char  **buf,   /* dest buffer */
     ** let's just assume it is an OOM condition, currently we have
     ** no input for this function that decodes to zero length data.
     */
-    if(buf64)
-      free(buf64);
+    free(buf64);
 
     return GPE_OUT_OF_MEMORY;
   }
@@ -435,15 +434,13 @@ int getpart(char **outbuf, size_t *outlen,
 
   } /* while */
 
-  if(buffer)
-    free(buffer);
+  free(buffer);
 
   if(error != GPE_OK) {
     if(error == GPE_END_OF_FILE)
       error = GPE_OK;
     else {
-      if(*outbuf)
-        free(*outbuf);
+      free(*outbuf);
       *outbuf = NULL;
       *outlen = 0;
     }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -523,8 +523,7 @@ static int ProcessRequest(struct httprequest *req)
           } while(ptr && *ptr);
           logmsg("Done parsing server commands");
         }
-        if(cmd)
-          free(cmd);
+        free(cmd);
       }
     }
     else {
@@ -993,8 +992,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     }
 
     if(got_exit_signal) {
-      if(ptr)
-        free(ptr);
+      free(ptr);
       return -1;
     }
 
@@ -1005,8 +1003,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       logmsg("fopen() failed with error: %d %s", error, strerror(error));
       logmsg("Error opening file: %s", filename);
       logmsg("Couldn't open test file");
-      if(ptr)
-        free(ptr);
+      free(ptr);
       return 0;
     }
     else {
@@ -1015,18 +1012,15 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       fclose(stream);
       if(error) {
         logmsg("getpart() failed with error: %d", error);
-        if(ptr)
-          free(ptr);
+        free(ptr);
         return 0;
       }
     }
   }
 
   if(got_exit_signal) {
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
@@ -1050,10 +1044,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     logmsg("fopen() failed with error: %d %s", error, strerror(error));
     logmsg("Error opening file: %s", RESPONSE_DUMP);
     logmsg("couldn't create logfile: " RESPONSE_DUMP);
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
@@ -1110,28 +1102,22 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
            RESPONSE_DUMP, error, strerror(error));
 
   if(got_exit_signal) {
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
   if(sendfailure) {
     logmsg("Sending response failed. Only (%zu bytes) of (%zu bytes) were sent",
            responsesize-count, responsesize);
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
   logmsg("Response sent (%zu bytes) and written to " RESPONSE_DUMP,
          responsesize);
-
-  if(ptr)
-    free(ptr);
+  free(ptr);
 
   if(cmdsize > 0 ) {
     char command[32];
@@ -1169,9 +1155,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
         ptr = NULL;
     } while(ptr && *ptr);
   }
-  if(cmd)
-    free(cmd);
-
+  free(cmd);
   req->open = persistant;
 
   prevtestno = req->testno;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -442,8 +442,7 @@ static int parse_servercmd(struct httprequest *req)
       else
         break;
     }
-    if(orgcmd)
-      free(orgcmd);
+    free(orgcmd);
   }
 
   return 0; /* OK! */
@@ -1126,8 +1125,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     }
 
     if(got_exit_signal) {
-      if(ptr)
-        free(ptr);
+      free(ptr);
       return -1;
     }
 
@@ -1137,8 +1135,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       error = errno;
       logmsg("fopen() failed with error: %d %s", error, strerror(error));
       logmsg("  [4] Error opening file: %s", filename);
-      if(ptr)
-        free(ptr);
+      free(ptr);
       return 0;
     }
     else {
@@ -1147,18 +1144,15 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       fclose(stream);
       if(error) {
         logmsg("getpart() failed with error: %d", error);
-        if(ptr)
-          free(ptr);
+        free(ptr);
         return 0;
       }
     }
   }
 
   if(got_exit_signal) {
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
@@ -1181,10 +1175,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     error = errno;
     logmsg("fopen() failed with error: %d %s", error, strerror(error));
     logmsg("  [5] Error opening file: %s", responsedump);
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
@@ -1228,28 +1220,22 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
            responsedump, error, strerror(error));
 
   if(got_exit_signal) {
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
   if(sendfailure) {
     logmsg("Sending response failed. Only (%zu bytes) of (%zu bytes) were sent",
            responsesize-count, responsesize);
-    if(ptr)
-      free(ptr);
-    if(cmd)
-      free(cmd);
+    free(ptr);
+    free(cmd);
     return -1;
   }
 
   logmsg("Response sent (%zu bytes) and written to %s",
          responsesize, responsedump);
-
-  if(ptr)
-    free(ptr);
+  free(ptr);
 
   if(cmdsize > 0 ) {
     char command[32];
@@ -1285,9 +1271,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
         ptr = NULL;
     } while(ptr && *ptr);
   }
-  if(cmd)
-    free(cmd);
-
+  free(cmd);
   req->open = use_gopher?FALSE:persistant;
 
   prevtestno = req->testno;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -876,8 +876,7 @@ int main(int argc, char **argv)
       memset(&test, 0, sizeof(test));
       if (do_tftp(&test, tp, n) < 0)
         break;
-      if(test.buffer)
-        free(test.buffer);
+      free(test.buffer);
     }
     sclose(peer);
     peer = CURL_SOCKET_BAD;
@@ -1089,8 +1088,7 @@ static int parse_servercmd(struct testcase *req)
       else
         break;
     }
-    if(orgcmd)
-      free(orgcmd);
+    free(orgcmd);
   }
 
   return 0; /* OK! */

--- a/tests/unit/unit1305.c
+++ b/tests/unit/unit1305.c
@@ -65,9 +65,7 @@ static void unit_stop( void )
     Curl_freeaddrinfo(data_node->addr);
     free(data_node);
   }
-  if (data_key)
-    free(data_key);
-
+  free(data_key);
   Curl_hash_destroy(hp);
 
   curl_easy_cleanup(data);


### PR DESCRIPTION
* [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
* The following functions perform also input parameter validation.
  * [Curl_cookie_cleanup](https://github.com/bagder/curl/blob/df5578a7a304a23f9aa3670daff8573ec3ef416f/lib/cookie.c#L1207 "Cookie clean-up")
  * [curl_formfree](https://github.com/bagder/curl/blob/df5578a7a304a23f9aa3670daff8573ec3ef416f/lib/formdata.c#L956 "Release a form post chain.")

  It is therefore not needed that a function caller repeats a corresponding check.