### PR TITLE
mkhelp: Remove trailing carriage return from every line of input

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -54,6 +54,9 @@ while (<STDIN>) {
     # this should be removed:
     $line =~ s/(.|_)//g;
 
+    # remove trailing CR from line. msysgit checks out files as line+CRLF
+    $line =~ s/\r$//;
+
     if($line =~ /^([ \t]*\n|curl)/i) {
         # cut off headers and empty lines
         $wline++; # count number of cut off lines
@@ -90,7 +93,12 @@ open(READ, "<$README") ||
     die "couldn't read the README infile $README";
 
 while(<READ>) {
-    push @out, $_;
+    my $line = $_;
+
+    # remove trailing CR from line. msysgit checks out files as line+CRLF
+    $line =~ s/\r$//;
+
+    push @out, $line;
 }
 close(READ);
 


### PR DESCRIPTION
- Get rid of this flood of warnings in Windows mingw build:

warning: missing terminating " character

The warning is due to the carriage return. When msysgit checks out files
from the repo by default it converts the line endings to CRLF. Prior to
this change when mkhelp.pl processed the MANUAL and curl.1 in CRLF
format the trailing carriage returns caused unnecessary CR in the
output.