### PR TITLE
curl_easy_setopt.3: Fix misspelling in CURLOPT_PATH_AS_IS description

### DIFF
--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -146,7 +146,7 @@ Fail on HTTP 4xx errors. \fICURLOPT_FAILONERROR(3)\fP
 .IP CURLOPT_URL
 URL to work on. See \fICURLOPT_URL(3)\fP
 .IP CURLOPT_PATH_AS_IS
-Disable squashing /../ and /./ sequences in tha path. See \fICURLOPT_PATH_AS_IS(3)\fP
+Disable squashing /../ and /./ sequences in the path. See \fICURLOPT_PATH_AS_IS(3)\fP
 .IP CURLOPT_PROTOCOLS
 Allowed protocols. See \fICURLOPT_PROTOCOLS(3)\fP
 .IP CURLOPT_REDIR_PROTOCOLS


### PR DESCRIPTION
s/tha/the/