### PR TITLE
globbing: fix step parsing for character globbing ranges

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -196,7 +196,7 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
       char *endp;
       unsigned long lstep;
       errno = 0;
-      lstep = strtoul(&pattern[3], &endp, 10);
+      lstep = strtoul(&pattern[4], &endp, 10);
       if(errno || (*endp != ']'))
         step = -1;
       else {


### PR DESCRIPTION
The glob_range function used wrong offset (3 instead of 4) for parsing integer step inside character range specification, which led to 'bad range' error when using character ranges with explicitly specified step (such as '[a-z:2]')