### PR TITLE
Cyassl fixes

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -640,7 +640,9 @@ int Curl_cyassl_random(struct SessionHandle *data,
   (void)data;
   if(InitRng(&rng))
     return 1;
-  if(RNG_GenerateBlock(&rng, entropy, length))
+  if(length > UINT_MAX)
+    return 1;
+  if(RNG_GenerateBlock(&rng, entropy, (unsigned)length))
     return 1;
   return 0;
 }

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -449,8 +449,8 @@ void Curl_cyassl_session_free(void *ptr)
 
 size_t Curl_cyassl_version(char *buffer, size_t size)
 {
-#if defined(LIBCYASSL_VERSION_STRING)
-  return snprintf(buffer, size, "CyaSSL/%s", LIBCYASSL_VERSION_STRING);
+#ifdef WOLFSSL_VERSION
+  return snprintf(buffer, size, "wolfSSL/%s", WOLFSSL_VERSION);
 #elif defined(CYASSL_VERSION)
   return snprintf(buffer, size, "CyaSSL/%s", CYASSL_VERSION);
 #else


### PR DESCRIPTION
cyassl: If wolfSSL then identify as such in version string
cyassl: Check for invalid length parameter in Curl_cyassl_random
cyassl: default to highest possible TLS version

wolfSSL maintainer's feedback regarding TLS version change is [here](http://curl.haxx.se/mail/lib-2014-11/0051.html). After some thought I decided to leave the short-circuit part in because frankly I like the guarantee. Although it's technically not necessary now it could be at some point in the future when their default setting is no longer TLS 1.x, even though it may be available.