### PR TITLE
globbing: fix url number calculation when using range with step

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -212,7 +212,7 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
     *posp += (pattern - *patternp);
 
     if((rc != 2) || (min_c >= max_c) || ((max_c - min_c) > ('z' - 'a')) ||
-       (step < 0) )
+       (step <= 0) )
       /* the pattern is not well-formed */
       return GLOBERROR("bad range", *posp, CURLE_URL_MALFORMAT);
 
@@ -222,7 +222,8 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
     pat->content.CharRange.max_c = max_c;
 
     if(multiply(amount, (pat->content.CharRange.max_c -
-                         pat->content.CharRange.min_c + 1)))
+                          pat->content.CharRange.min_c) /
+                         pat->content.CharRange.step + 1) )
       return GLOBERROR("range overflow", *posp, CURLE_URL_MALFORMAT);
   }
   else if(ISDIGIT(*pattern)) {
@@ -276,7 +277,8 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
 
     *posp += (pattern - *patternp);
 
-    if(!endp || (min_n > max_n) || (step_n > (max_n - min_n)))
+    if(!endp || (min_n > max_n) || (step_n > (max_n - min_n)) || 
+       (step_n <= 0) )
       /* the pattern is not well-formed */
       return GLOBERROR("bad range", *posp, CURLE_URL_MALFORMAT);
 
@@ -287,7 +289,8 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
     pat->content.NumRange.step = step_n;
 
     if(multiply(amount, (pat->content.NumRange.max_n -
-                         pat->content.NumRange.min_n + 1)))
+                         pat->content.NumRange.min_n) /
+                        pat->content.NumRange.step + 1) )
       return GLOBERROR("range overflow", *posp, CURLE_URL_MALFORMAT);
   }
   else


### PR DESCRIPTION
In function glob_range, the number of urls was multiplied by (max - min + 1), regardless of step. The correct formula is (max - min) / step + 1