### PR TITLE
Ssl version validity checks

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -892,7 +892,11 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
      * Set explicit SSL version to try to connect with, as some SSL
      * implementations are lame.
      */
+#ifdef USE_SSL
     data->set.ssl.version = va_arg(param, long);
+#else
+    result = CURLE_UNKNOWN_OPTION;
+#endif
     break;
 
 #ifndef CURL_DISABLE_HTTP

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -276,10 +276,25 @@ void Curl_ssl_cleanup(void)
   }
 }
 
+bool ssl_prefs_check(struct SessionHandle *data)
+{
+  /* check for CURLOPT_SSLVERSION invalid parameter value */
+  if((data->set.ssl.version < 0)
+     || (data->set.ssl.version >= CURL_SSLVERSION_LAST)) {
+    failf(data, "Unrecognized parameter value passed via CURLOPT_SSLVERSION");
+    return FALSE;
+  }
+  return TRUE;
+}
+
 CURLcode
 Curl_ssl_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode result;
+
+  if(!ssl_prefs_check(conn->data))
+    return CURLE_SSL_CONNECT_ERROR;
+
   /* mark this is being ssl-enabled from here on. */
   conn->ssl[sockindex].use = TRUE;
   conn->ssl[sockindex].state = ssl_connection_negotiating;
@@ -297,6 +312,10 @@ Curl_ssl_connect_nonblocking(struct connectdata *conn, int sockindex,
                              bool *done)
 {
   CURLcode result;
+
+  if(!ssl_prefs_check(conn->data))
+    return CURLE_SSL_CONNECT_ERROR;
+
   /* mark this is being ssl requested from here on. */
   conn->ssl[sockindex].use = TRUE;
 #ifdef curlssl_connect_nonblocking


### PR DESCRIPTION
Changes made as discussed [here](http://curl.haxx.se/mail/lib-2015-02/0060.html) (last paragraph). The unknown value check could be expanded to include a check in url.c to check for an unknown version value in the parameter, like this:
```c
#ifdef USE_SSL
    data->set.ssl.version = va_arg(param, long);
    if((data->set.ssl.version < 0)
       || (data->set.ssl.version >= CURL_SSLVERSION_LAST))
      result = CURLE_UNKNOWN_PARAM_VALUE; //or something..
#else
    result = CURLE_UNKNOWN_OPTION;
#endif
```
Note the parameter is still set even though it's unknown. I figure it would be better to do that to cause the fail later on in the SSL since that will be visible to the user rather than just ignore the value and fail silently not sure.