### PR TITLE
checksrc: Windows-specific input fixes

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -30,14 +30,15 @@ my $supressed; # whitelisted problems
 my $file;
 my $dir=".";
 my $wlist;
+my $windows_os = $^O eq 'MSWin32' || $^O eq 'msys' || $^O eq 'cygwin';
 
 my %whitelist;
 
 sub readwhitelist {
     open(W, "<$dir/checksrc.whitelist");
     my @all=<W>;
-    for(@all)  {
-        chomp;
+    for(@all) {
+        $windows_os ? $_ =~ s/\r?\n$// : chomp;
         $whitelist{$_}=1;
     }
     close(W);
@@ -120,7 +121,7 @@ sub scanfile {
     my $copyright=0;
 
     while(<R>) {
-        chomp;
+        $windows_os ? $_ =~ s/\r?\n$// : chomp;
         my $l = $_;
         my $column = 0;
 

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -443,6 +443,6 @@
 #define ENOMEM 2
 #define EAGAIN 3
 
-extern int stat(const char *path,struct stat *buffer );
+extern int stat(const char *path, struct stat *buffer);
 
 #endif /* HEADER_CURL_CONFIG_WIN32CE_H */

--- a/projects/checksrc.bat
+++ b/projects/checksrc.bat
@@ -46,7 +46,7 @@ rem ***************************************************************************
   if not exist "%SRC_DIR%" goto nosrc
 
 :start
-  for /f "delims=" %%i in ('dir %SRC_DIR%\src\*.c.* /b') do @perl %SRC_DIR%\lib\checksrc.pl -D%SRC_DIR%\src "%%i"
+  for /f "delims=" %%i in ('dir %SRC_DIR%\src\*.c.* /b') do @perl %SRC_DIR%\lib\checksrc.pl -D%SRC_DIR%\src -Wtool_hugehelp.c "%%i"
   for /f "delims=" %%i in ('dir %SRC_DIR%\src\*.h.* /b') do @perl %SRC_DIR%\lib\checksrc.pl -D%SRC_DIR%\src "%%i"
   for /f "delims=" %%i in ('dir %SRC_DIR%\lib\*.c.* /b') do @perl %SRC_DIR%\lib\checksrc.pl -D%SRC_DIR%\lib "%%i"
   for /f "delims=" %%i in ('dir %SRC_DIR%\lib\*.h.* /b') do @perl %SRC_DIR%\lib\checksrc.pl -D%SRC_DIR%\lib -Wcurl_config.h.cmake "%%i"


### PR DESCRIPTION
lib/config-win32ce.h
- Fix whitespace for checksrc compliance.

lib/checksrc.pl
- Remove trailing carriage returns from input.

projects/checksrc.bat
- Ignore tool_hugehelp.c.