### PR TITLE
cyassl: Fix library initialization return value

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -496,10 +496,7 @@ size_t Curl_cyassl_version(char *buffer, size_t size)
 
 int Curl_cyassl_init(void)
 {
-  if(CyaSSL_Init() == 0)
-    return 1;
-
-  return -1;
+  return (CyaSSL_Init() == SSL_SUCCESS);
 }
 
 


### PR DESCRIPTION
(Curl_cyassl_init)
- Return 1 on success, 0 in failure.

Prior to this change the fail path returned an incorrect value and the
evaluation to determine whether CyaSSL_Init had succeeded was incorrect.
Ironically that combined with the way curl_global_init tests SSL library
initialization (!Curl_ssl_init()) meant that CyaSSL having been
successfully initialized would be seen as that even though the code path
and return value in Curl_cyassl_init were wrong.