### PR TITLE
Mainly SHOUTcast servers use "ICY 200 OK"

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
@@ -32,9 +32,11 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTP200ALIASES,
 .SH DESCRIPTION
 Pass a pointer to a linked list of \fIaliases\fP to be treated as valid HTTP
 200 responses.  Some servers respond with a custom header response line.  For
-example, IceCast servers respond with "ICY 200 OK".  By including this string
-in your list of aliases, the response will be treated as a valid HTTP header
-line such as "HTTP/1.0 200 OK".
+example, SHOUTcast servers respond with "ICY 200 OK". Also some very old
+Icecast 1.3.x servers will respond like that for certain user agent headers or
+in absence of such. By including this string in your list of aliases,
+the response will be treated as a valid HTTP header line such as
+"HTTP/1.0 200 OK".
 
 The linked list should be a fully valid list of struct curl_slist structs, and
 be properly filled in.  Use \fIcurl_slist_append(3)\fP to create the list and


### PR DESCRIPTION
Icecast versions 1.3.0 through 1.3.12 would reply with "ICY 200 OK"
under certain conditions:

    client_wants_icy_headers (connection_t *con)
    {
            const char *val;

            if (!con)
                    return 1;

            val = get_user_agent (con);
            if (!val || !val[0] || strcmp (val, "(null)") == 0)
                    return 1;

            if (con->food.client->use_icy)
                    return 1;
            if (strncasecmp (val, "winamp", 6) == 0)
                    return 1;
            if (strncasecmp (val, "Shoutcast", 9) == 0)
                    return 1;

            return 0;
    }

So mainly if there is no 'user agent' or it is '(null)' or contains
'winamp' or 'Shoutcast'.

No mainstream distribution carries Icecast 1.3.x anymore, after all
it was released in 2002 and superseded by Icecast 2.x.