### PR TITLE
http2: Fix missing nghttp2_session_send call in Curl_http2_switched

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1062,6 +1062,15 @@ CURLcode Curl_http2_switched(struct connectdata *conn,
     return CURLE_HTTP2;
   }
 
+  /* Try to send some frames since we may read SETTINGS already. */
+  rv = nghttp2_session_send(httpc->h2);
+
+  if(rv != 0) {
+    failf(data, "nghttp2_session_send() failed: %s(%d)",
+          nghttp2_strerror(rv), rv);
+    return CURLE_HTTP2;
+  }
+
   return CURLE_OK;
 }
 


### PR DESCRIPTION
Previously in Curl_http2_switched, we called nghttp2_session_mem_recv
to parse incoming data which were already received while curl was
handling upgrade.  But we didn't call nghttp2_session_send, and it led
to make curl not send any response to the received frames.  Most
likely, we received SETTINGS from server at this point, so we missed
opportunity to send SETTINGS + ACK.  This commit adds missing
nghttp2_session_send call in Curl_http2_switched to fix this issue.