### PR TITLE
cyassl: Remove 'Connecting to' message from cyassl_connect_step2

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -282,9 +282,6 @@ cyassl_connect_step2(struct connectdata *conn,
   struct SessionHandle *data = conn->data;
   struct ssl_connect_data* conssl = &conn->ssl[sockindex];
 
-  infof(data, "CyaSSL: Connecting to %s:%d\n",
-        conn->host.name, conn->remote_port);
-
   conn->recv[sockindex] = cyassl_recv;
   conn->send[sockindex] = cyassl_send;
 


### PR DESCRIPTION
Prior to this change libcurl could show multiple 'CyaSSL: Connecting to'
messages since cyassl_connect_step2 is called multiple times, typically.
The message is superfluous even once since libcurl already informs the
user elsewhere in code that it is connecting.