### PR TITLE
x509asn1: Silence x64 loss-of-data warning on RSA key length assignment

### DIFF
--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -820,7 +820,7 @@ static void do_pubkey(struct SessionHandle * data, int certnum,
     /* Compute key length. */
     for(q = elem.beg; !*q && q < elem.end; q++)
       ;
-    len = (elem.end - q) * 8;
+    len = (unsigned long)((elem.end - q) * 8);
     if(len)
       for(i = *(unsigned char *) q; !(i & 0x80); i <<= 1)
         len--;


### PR DESCRIPTION
The key length in bits will always fit in an unsigned long so the
loss-of-data warning assigning the result of x64 pointer arithmetic to
an unsigned long is unnecessary.