### PR TITLE
cyassl: Implement public key pinning

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -50,11 +50,22 @@ if(curl) {
   curl_easy_perform(curl);
 }
 .fi
+.SH PUBLIC KEY EXTRACTION
+If you do not have the server's public key file you can extract it from the
+server's certificate.
+.nf
+openssl x509 -in www.test.com.pem -pubkey -noout > www.test.com.pubkey.pem
+.fi
+The public key is output in PEM format and contains a header, base64 data and a
+footer:
+.nf
+-----BEGIN PUBLIC KEY-----
+[BASE 64 DATA]
+-----END PUBLIC KEY-----
+.fi
 .SH AVAILABILITY
-If built TLS enabled. This is currently only implemented in the OpenSSL,
-GnuTLS and GSKit backends.
-
-Added in libcurl 7.39.0
+Added in 7.39.0 for OpenSSL, GnuTLS and GSKit. Added in 7.43.0 for
+wolfSSL/CyaSSL. Other SSL backends not supported.
 .SH RETURN VALUE
 Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -43,6 +43,7 @@
 #include "connect.h" /* for the connect timeout */
 #include "select.h"
 #include "rawstr.h"
+#include "x509asn1.h"
 #include "curl_printf.h"
 
 #include <cyassl/ssl.h>
@@ -354,6 +355,44 @@ cyassl_connect_step2(struct connectdata *conn,
       failf(data, "SSL_connect failed with error %d: %s", detail,
           ERR_error_string(detail, error_buffer));
       return CURLE_SSL_CONNECT_ERROR;
+    }
+  }
+
+  if(data->set.str[STRING_SSL_PINNEDPUBLICKEY]) {
+    X509 *x509;
+    const char *x509_der;
+    int x509_der_len;
+    curl_X509certificate x509_parsed;
+    curl_asn1Element *pubkey;
+    CURLcode result;
+
+    x509 = SSL_get_peer_certificate(conssl->handle);
+    if(!x509) {
+      failf(data, "SSL: failed retrieving server certificate");
+      return CURLE_SSL_PINNEDPUBKEYNOTMATCH;
+    }
+
+    x509_der = (const char *)CyaSSL_X509_get_der(x509, &x509_der_len);
+    if(!x509_der) {
+      failf(data, "SSL: failed retrieving ASN.1 server certificate");
+      return CURLE_SSL_PINNEDPUBKEYNOTMATCH;
+    }
+
+    memset(&x509_parsed, 0, sizeof x509_parsed);
+    Curl_parseX509(&x509_parsed, x509_der, x509_der + x509_der_len);
+
+    pubkey = &x509_parsed.subjectPublicKeyInfo;
+    if(!pubkey->header || pubkey->end <= pubkey->header) {
+      failf(data, "SSL: failed retrieving public key from server certificate");
+      return CURLE_SSL_PINNEDPUBKEYNOTMATCH;
+    }
+
+    result = Curl_pin_peer_pubkey(data->set.str[STRING_SSL_PINNEDPUBLICKEY],
+                                  (const unsigned char *)pubkey->header,
+                                  (size_t)(pubkey->end - pubkey->header));
+    if(result) {
+      failf(data, "SSL: public key does not match pinned public key!");
+      return result;
     }
   }
 

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -22,7 +22,8 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS)
+#if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS) || \
+    defined(USE_CYASSL)
 
 #include <curl/curl.h>
 #include "urldata.h"
@@ -1023,7 +1024,7 @@ CURLcode Curl_extract_certinfo(struct connectdata * conn,
   return CURLE_OK;
 }
 
-#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS */
+#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_CYASSL */
 
 #if defined(USE_GSKIT)
 

--- a/lib/x509asn1.h
+++ b/lib/x509asn1.h
@@ -25,7 +25,8 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS)
+#if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS) || \
+    defined(USE_CYASSL)
 
 #include "urldata.h"
 
@@ -127,5 +128,5 @@ CURLcode Curl_extract_certinfo(struct connectdata * conn, int certnum,
 CURLcode Curl_verifyhost(struct connectdata * conn,
                          const char * beg, const char * end);
 
-#endif /* USE_GSKIT or USE_NSS or  USE_GNUTLS */
+#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_CYASSL */
 #endif /* HEADER_CURL_X509ASN1_H */


### PR DESCRIPTION
Also add public key extraction example to CURLOPT_PINNEDPUBLICKEY doc.

Note in the documentation I put 'Added in 7.43.0' because it's past the feature window for 7.42. This could be merged after April 22?, or whatever date 7.42 is released.
