### PR TITLE
lib/makefile.m32: add missing libs to build libcurl.dll

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -214,6 +214,9 @@ ifdef SSL
       OPENSSL_LIBS = -lcrypto -lssl
     endif
   endif
+  ifndef DYN
+    OPENSSL_LIBS += -lgdi32 -lcrypt32
+  endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL -DHAVE_OPENSSL_ENGINE_H -DHAVE_OPENSSL_PKCS12_H \
             -DHAVE_ENGINE_LOAD_BUILTIN_ENGINES -DOPENSSL_NO_KRB5 \


### PR DESCRIPTION
Add 'gdi32' and 'crypt32' Windows implibs to avoid failure 
while building libcurl.dll using the mingw compiler.
The same logic is used in 'src/makefile.m32' when 
building curl.exe.