### PR TITLE
netrc: support 'default' token

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -137,6 +137,10 @@ int Curl_parsenetrc(const char *host,
                'password'. */
             state=HOSTFOUND;
           }
+          else if(Curl_raw_equal("default", tok)) {
+            state=HOSTVALID;
+            retcode=0; /* we did find our host */
+          }
           break;
         case HOSTFOUND:
           if(Curl_raw_equal(host, tok)) {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -165,4 +165,4 @@ test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
 test2008 test2009 test2010 test2011 test2012 test2013 test2014 test2015 \
 test2016 test2017 test2018 test2019 test2020 test2021 test2022 test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \
-test2032 test2033 test2034 test2035 test2036 test2037 test2038
+test2032 test2033 test2034 test2035 test2036 test2037 test2038 test2039

--- a/tests/data/test2039
+++ b/tests/data/test2039
@@ -37,9 +37,9 @@ ftp
 FTP (optional .netrc with 'default' override; no user/pass) dir list PASV
  </name>
  <command>
---netrc-optional --netrc-file log/netrc130 ftp://%HOSTIP:%FTPPORT/
+--netrc-optional --netrc-file log/netrc2039 ftp://%HOSTIP:%FTPPORT/
 </command>
-<file name="log/netrc130" >
+<file name="log/netrc2039" >
 # the following two lines were created while testing curl
 default login userdef password passwddef
 machine %HOSTIP login user1 password passwd1

--- a/tests/data/test2039
+++ b/tests/data/test2039
@@ -34,16 +34,16 @@ dr-xr-xr-x   5 0        1            512 Oct  1  1997 usr
 ftp
 </server>
  <name>
-FTP (optional .netrc; no user/pass) dir list PASV
+FTP (optional .netrc with 'default' override; no user/pass) dir list PASV
  </name>
  <command>
 --netrc-optional --netrc-file log/netrc130 ftp://%HOSTIP:%FTPPORT/
 </command>
 <file name="log/netrc130" >
 # the following two lines were created while testing curl
+default login userdef password passwddef
 machine %HOSTIP login user1 password passwd1
 machine %HOSTIP login user2 password passwd2
-default login userdef password passwddef
 </file>
 </client>
 
@@ -51,8 +51,8 @@ default login userdef password passwddef
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-USER user1
-PASS passwd1
+USER userdef
+PASS passwddef
 PWD
 EPSV
 TYPE A


### PR DESCRIPTION
The 'default' token has no argument and means to match _any_ domain.
It must be placed last if there are 'machine \<name\>' tokens in the same file.

See full description here:
https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-File.html