### PR TITLE
remove unneeded libraries from nss fallback kludge

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2139,7 +2139,7 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
       # Without pkg-config, we'll kludge in some defaults
       AC_MSG_WARN([Using hard-wired libraries and compilation flags for NSS.])
       addld="-L$OPT_NSS/lib"
-      addlib="-lssl3 -lsmime3 -lnss3 -lplds4 -lplc4 -lnspr4 -lpthread -ldl"
+      addlib="-lssl3 -lsmime3 -lnss3 -lplds4 -lplc4 -lnspr4"
       addcflags="-I$OPT_NSS/include"
       version="unknown"
       nssprefix=$OPT_NSS


### PR DESCRIPTION
Neither libpthread nor libdl seem to be required by nss (I checked fedora and ubuntu packages, as well as nss built from source), so we should remove these from the non pkg-config fallback kludge.