### PR TITLE
sync nss fallback libs with standard nss pkg-config setup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2139,7 +2139,7 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
       # Without pkg-config, we'll kludge in some defaults
       AC_MSG_WARN([Using hard-wired libraries and compilation flags for NSS.])
       addld="-L$OPT_NSS/lib"
-      addlib="-lssl3 -lsmime3 -lnss3 -lplds4 -lplc4 -lnspr4"
+      addlib="-lnss3 -lnssutil3 -lsmime3 -lssl3 -lplds4 -lplc4 -lnspr4"
       addcflags="-I$OPT_NSS/include"
       version="unknown"
       nssprefix=$OPT_NSS


### PR DESCRIPTION
This patch syncs the nss fallback libs with the same values from the official nss build's pkg-config files:
add -lnssutil3 and reorder a bit.

Followup to pull request #227.