### PR TITLE
Raw Data Option

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -315,9 +315,10 @@ presses the submit button. This will cause curl to pass the data to the server
 using the content-type application/x-www-form-urlencoded.  Compare to
 \fI-F, --form\fP.
 
-\fI-d, --data\fP is the same as \fI--data-ascii\fP. To post data purely binary,
-you should instead use the \fI--data-binary\fP option. To URL-encode the value
-of a form field you may use \fI--data-urlencode\fP.
+\fI-d, --data\fP is the same as \fI--data-ascii\fP. \fI--data-raw\fP is almost
+the same but does not have a special interpretation of the @ character. To
+post data purely binary, you should instead use the\fI--data-binary\fP option.
+To URL-encode the value of a form field you may use \fI--data-urlencode\fP.
 
 If any of these options is used more than once on the same command line, the
 data pieces specified will be merged together with a separating
@@ -329,7 +330,9 @@ read the data from, or - if you want curl to read the data from
 stdin. Multiple files can also be specified. Posting data from a file
 named 'foobar' would thus be done with \fI--data\fP @foobar. When --data is
 told to read from a file like that, carriage returns and newlines will be
-stripped out.
+stripped out. If you don't want the @ character to have a special
+interpretation use \fI--data-raw\fP instead.
+
 .IP "-D, --dump-header <file>"
 Write the protocol headers to the specified file.
 
@@ -354,6 +357,12 @@ and carriage returns are preserved and conversions are never done.
 
 If this option is used several times, the ones following the first will append
 data as described in \fI-d, --data\fP.
+
+.IP "--data-raw <data>"
+(HTTP) This posts data similarly to \fI--data\fP but without the special
+interpretation of the @ character. See \fI-d, --data\fP.
+(Added in 7.43.0)
+
 .IP "--data-urlencode <data>"
 (HTTP) This posts data, similar to the other --data options with the exception
 that this performs URL-encoding. (Added in 7.18.0)

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -196,6 +196,7 @@ static const struct LongShort aliases[]= {
   {"c",  "cookie-jar",               TRUE},
   {"C",  "continue-at",              TRUE},
   {"d",  "data",                     TRUE},
+  {"dr", "data-raw",                 TRUE},
   {"da", "data-ascii",               TRUE},
   {"db", "data-binary",              TRUE},
   {"de", "data-urlencode",           TRUE},
@@ -1099,6 +1100,7 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
       char *postdata = NULL;
       FILE *file;
       size_t size = 0;
+      bool raw_mode = (subletter == 'r');
 
       if(subletter == 'e') { /* --data-urlencode*/
         /* [name]=[content], we encode the content part only
@@ -1124,7 +1126,6 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
         }
         if('@' == is_file) {
           /* a '@' letter, it means that a file name or - (stdin) follows */
-
           if(curlx_strequal("-", p)) {
             file = stdin;
             set_binmode(stdin);
@@ -1185,7 +1186,7 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
             return PARAM_NO_MEM;
         }
       }
-      else if('@' == *nextarg) {
+      else if('@' == *nextarg && !raw_mode) {
         /* the data begins with a '@' letter, it means that a file name
            or - (stdin) follows */
         nextarg++; /* pass the @ */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -65,7 +65,7 @@ static const char *const helptext[] = {
   "     --crlf          Convert LF to CRLF in upload",
   "     --crlfile FILE  Get a CRL list in PEM format from the given file",
   " -d, --data DATA     HTTP POST data (H)",
-  "     --data-raw      HTTP POST data (H), '@' allowed",
+  "     --data-raw      HTTP POST data, '@' allowed (H)",
   "     --data-ascii DATA  HTTP POST ASCII data (H)",
   "     --data-binary DATA  HTTP POST binary data (H)",
   "     --data-urlencode DATA  HTTP POST data url encoded (H)",

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -65,6 +65,7 @@ static const char *const helptext[] = {
   "     --crlf          Convert LF to CRLF in upload",
   "     --crlfile FILE  Get a CRL list in PEM format from the given file",
   " -d, --data DATA     HTTP POST data (H)",
+  "     --data-raw      HTTP POST data (H), '@' allowed",
   "     --data-ascii DATA  HTTP POST ASCII data (H)",
   "     --data-binary DATA  HTTP POST binary data (H)",
   "     --data-urlencode DATA  HTTP POST data url encoded (H)",

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -65,7 +65,7 @@ static const char *const helptext[] = {
   "     --crlf          Convert LF to CRLF in upload",
   "     --crlfile FILE  Get a CRL list in PEM format from the given file",
   " -d, --data DATA     HTTP POST data (H)",
-  "     --data-raw      HTTP POST data, '@' allowed (H)",
+  "     --data-raw DATA  HTTP POST data, '@' allowed (H)",
   "     --data-ascii DATA  HTTP POST ASCII data (H)",
   "     --data-binary DATA  HTTP POST binary data (H)",
   "     --data-urlencode DATA  HTTP POST data url encoded (H)",


### PR DESCRIPTION
Creates a new option, '--data-raw', which allows the '@' symbol to be used in postfield data. Also updates the -help printout to include the new option.