### PR TITLE
lib/makefile.m32: add arch option to LDFLAGS

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -76,9 +76,11 @@ endif
 
 ifeq ($(ARCH),w64)
 CFLAGS  += -m64 -D_AMD64_
+LDFLAGS += -m64
 RCFLAGS += -F pe-x86-64
 else
 CFLAGS  += -m32
+LDFLAGS += -m32
 RCFLAGS += -F pe-i386
 endif
 


### PR DESCRIPTION
This fixes using a multi-target mingw distro to build curl .dll for the non-default target.
(mirroring the same patch present in src/makefile.m32)