### PR TITLE
configure: remove --automake from libtoolize call

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -330,7 +330,7 @@ done
 #
 
 echo "buildconf: running libtoolize"
-${libtoolize} --copy --automake --force || die "libtoolize command failed"
+${libtoolize} --copy --force || die "libtoolize command failed"
 
 # When using libtool 1.5.X (X < 26) we copy libtool.m4 to our local m4
 # subdirectory and this local copy is patched to fix some warnings that


### PR DESCRIPTION
That option is not mentioned in the man page of libtoolize 2.4.4.19-fda4.
Moveover, a comment in line 2623 says "--automake is for 1.5 compatibility".

This option is redundant now.