### PR TITLE
acinclude.m4: fix test for default CA cert bundle/path

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2676,7 +2676,7 @@ AC_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     AC_DEFINE_UNQUOTED(CURL_CA_PATH, "$capath", [Location of default ca path])
     AC_MSG_RESULT([$capath (capath)])
   fi
-  if test "x$ca" == "xno" && test "x$capath" == "xno"; then
+  if test "x$ca" = "xno" && test "x$capath" = "xno"; then
     AC_MSG_RESULT([no])
   fi
 ])


### PR DESCRIPTION
test(1) on HP-UX requires a single equals sign and fails with two.
Let's use one and make every OS happy.

I see this error in `./configure`:

    checking for SRP_Calc_client_key in -lcrypto... no
    checking default CA cert bundle/path... ./configure[24752]: ==: A test command parameter is not valid.
    checking for libssh2_channel_open_ex in -lssh2... no

This is basically the same error as in [this](https://github.com/krb5/krb5/pull/192) PR. Which has been fixed [here](https://github.com/krb5/krb5/commit/fefd465614f11f374f5ff183e6eb6cbc1b550de5).