### PR TITLE
[updated] NTLM don't panic when getting 401 on authenticated connection

### DIFF
--- a/lib/curl_ntlm.c
+++ b/lib/curl_ntlm.c
@@ -85,10 +85,16 @@ CURLcode Curl_input_ntlm(struct connectdata *conn,
     }
     else {
       if(ntlm->state == NTLMSTATE_TYPE3) {
-        infof(conn->data, "NTLM handshake rejected\n");
-        Curl_http_ntlm_cleanup(conn);
-        ntlm->state = NTLMSTATE_NONE;
-        return CURLE_REMOTE_ACCESS_DENIED;
+        if(ntlm->persist_auth) {
+          Curl_http_ntlm_cleanup(conn);
+          ntlm->persist_auth = FALSE;
+        }
+        else {
+          Curl_http_ntlm_cleanup(conn);
+          infof(conn->data, "NTLM handshake rejected\n");
+          ntlm->state = NTLMSTATE_NONE;
+          return CURLE_REMOTE_ACCESS_DENIED;
+        }
       }
       else if(ntlm->state >= NTLMSTATE_TYPE1) {
         infof(conn->data, "NTLM handshake failure (internal error)\n");

--- a/lib/http.c
+++ b/lib/http.c
@@ -721,10 +721,7 @@ Curl_http_output_auth(struct connectdata *conn,
      !data->state.first_host ||
      data->set.http_disable_hostname_check_before_authentication ||
      Curl_raw_equal(data->state.first_host, conn->host.name)) {
-     /* If we expect 407 from proxy as auth isn't done yet with this request
-        then don't bother authenticating to server as it won't reach it */
-      if(authproxy->done)
-        result = output_auth_headers(conn, authhost, request, path, FALSE);
+    result = output_auth_headers(conn, authhost, request, path, FALSE);
   }
   else
     authhost->done = TRUE;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1436,6 +1436,19 @@ CURLcode Curl_http_done(struct connectdata *conn,
 
   Curl_unencode_cleanup(conn);
 
+#if defined(USE_NTLM)
+  if((!conn->ntlm.persist_auth) &&
+     (data->req.httpcode != 401) &&
+      (conn->ntlm.state == NTLMSTATE_TYPE3))
+        conn->ntlm.persist_auth = TRUE;
+#if !defined(CURL_DISABLE_PROXY)
+  if((!conn->proxyntlm.persist_auth) &&
+     (data->req.httpcode != 407) &&
+      (conn->proxyntlm.state == NTLMSTATE_TYPE3))
+        conn->proxyntlm.persist_auth = TRUE;
+#endif
+#endif
+
 #ifdef USE_SPNEGO
   if(data->state.proxyneg.state == GSS_AUTHSENT ||
      data->state.negotiate.state == GSS_AUTHSENT) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -721,7 +721,10 @@ Curl_http_output_auth(struct connectdata *conn,
      !data->state.first_host ||
      data->set.http_disable_hostname_check_before_authentication ||
      Curl_raw_equal(data->state.first_host, conn->host.name)) {
-    result = output_auth_headers(conn, authhost, request, path, FALSE);
+     /* If we expect 407 from proxy as auth isn't done yet with this request
+        then don't bother authenticating to server as it won't reach it */
+      if(authproxy->done)
+        result = output_auth_headers(conn, authhost, request, path, FALSE);
   }
   else
     authhost->done = TRUE;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -426,6 +426,7 @@ struct kerberos5data {
 #if defined(USE_NTLM)
 struct ntlmdata {
   curlntlm state;
+  bool persist_auth;
 #ifdef USE_WINDOWS_SSPI
   CredHandle *credentials;
   CtxtHandle *context;


### PR DESCRIPTION
The fix saves the extra header (tested it with several combinations of server and proxy auth methods).

This is currently only relevant for NTLM (and digest) as other auth methods set proxy-auth done by adding their authz header (it could in theory be relevant to Negotiate as well when NTLM is used).