### PR TITLE
Update the version number in curl/curlver.h to the correct version.

### DIFF
--- a/include/curl/curlver.h
+++ b/include/curl/curlver.h
@@ -30,13 +30,13 @@
 
 /* This is the version number of the libcurl package from which this header
    file origins: */
-#define LIBCURL_VERSION "7.42.0-DEV"
+#define LIBCURL_VERSION "7.42.1"
 
 /* The numeric version number is also available "in parts" by using these
    defines: */
 #define LIBCURL_VERSION_MAJOR 7
 #define LIBCURL_VERSION_MINOR 42
-#define LIBCURL_VERSION_PATCH 0
+#define LIBCURL_VERSION_PATCH 1
 
 /* This is the numeric version of the libcurl version number, meant for easier
    parsing and comparions by programs. The LIBCURL_VERSION_NUM define will
@@ -53,7 +53,7 @@
    and it is always a greater number in a more recent release. It makes
    comparisons with greater than and less than work.
 */
-#define LIBCURL_VERSION_NUM 0x072A00
+#define LIBCURL_VERSION_NUM 0x072A01
 
 /*
  * This is the date and time when the full source package was created. The


### PR DESCRIPTION
Bit of pickyness. The version number still read 7.42.0-DEV.  Updated it to 7.42.1

