### PR TITLE
Fix netrc parsing on Windows

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -109,7 +109,7 @@ int Curl_parsenetrc(const char *host,
     netrc_alloc = TRUE;
   }
 
-  file = fopen(netrcfile, "r");
+  file = fopen(netrcfile, "rt");
   if(netrc_alloc)
     free(netrcfile);
   if(file) {


### PR DESCRIPTION
Open it in text mode to avoid considering CR as part of the line