### PR TITLE
netrc: Windows check USERPROFILE for home directory

### DIFF
--- a/docs/MANUAL
+++ b/docs/MANUAL
@@ -866,9 +866,10 @@ NETRC
   passwords, so therefore most unix programs won't read this file unless it is
   only readable by yourself (curl doesn't care though).
 
-  Curl supports .netrc files if told to (using the -n/--netrc and
-  --netrc-optional options). This is not restricted to just FTP,
-  so curl can use it for all protocols where authentication is used.
+  Curl supports .netrc (\fI_netrc\fP on Windows if not a POSIX-only build)
+  files if told to (using the -n/--netrc, --netrc-file and --netrc-optional
+  options). This is not restricted to just FTP, so curl can use it for all
+  protocols where authentication is used.
 
   A very simple .netrc file could look something like:
 

--- a/docs/curl.1
+++ b/docs/curl.1
@@ -1056,16 +1056,18 @@ in Metalink file, hash check will fail.
 
 (Added in 7.27.0, if built against the libmetalink library.)
 .IP "-n, --netrc"
-Makes curl scan the \fI.netrc\fP (\fI_netrc\fP on Windows) file in the user's
-home directory for login name and password. This is typically used for FTP on
-Unix. If used with HTTP, curl will enable user authentication. See
+Makes curl scan the \fI.netrc\fP (\fI_netrc\fP on Windows if not a POSIX-only
+build) file in the user's home directory for login name and password. This is
+typically used for FTP on Unix. If used with HTTP, curl will enable user
+authentication. See
 .BR netrc(4)
 or
 .BR ftp(1)
 for details on the file format. Curl will not complain if that file
 doesn't have the right permissions (it should not be either world- or
 group-readable). The environment variable "HOME" is used to find the home
-directory.
+directory. Starting in 7.43.0 on Windows when "HOME" is not defined
+"USERPROFILE" is used instead.
 
 A quick and very simple example of how to setup a \fI.netrc\fP to allow curl
 to FTP to the machine host.domain.com with user name \&'myself' and password

--- a/docs/libcurl/opts/CURLOPT_NETRC.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC.3
@@ -32,6 +32,12 @@ This parameter controls the preference \fIlevel\fP of libcurl between using
 user names and passwords from your \fI~/.netrc\fP file, relative to user names
 and passwords in the URL supplied with \fICURLOPT_URL(3)\fP.
 
+The .netrc file (\fI_netrc\fP on Windows if not a POSIX-only build) is read
+from the user's home directory unless you have specified
+\fICURLOPT_NETRC_FILE(3)\fP. The environment variable "HOME" is used to find
+the home directory. Starting in 7.43.0 on Windows when "HOME" is not defined
+"USERPROFILE" is used instead.
+
 libcurl uses a user name (and supplied or prompted password) supplied with
 \fICURLOPT_USERPWD(3)\fP or \fICURLOPT_USERNAME(3)\fP in preference to any of
 the options controlled by this parameter.

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -72,6 +72,10 @@ int Curl_parsenetrc(const char *host,
   if(!netrcfile) {
     bool home_alloc = FALSE;
     char *home = curl_getenv("HOME"); /* portable environment reader */
+#if defined(WIN32) || defined(__CYGWIN__)
+    if(!home)
+      home = curl_getenv("USERPROFILE");
+#endif
     if(home) {
       home_alloc = TRUE;
 #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -140,8 +140,9 @@ static const char *const helptext[] = {
   " -m, --max-time SECONDS  Maximum time allowed for the transfer",
   "     --metalink      Process given URLs as metalink XML file",
   "     --negotiate     Use HTTP Negotiate (SPNEGO) authentication (H)",
-  " -n, --netrc         Must read .netrc for user name and password",
-  "     --netrc-optional  Use either .netrc or URL; overrides -n",
+  " -n, --netrc         Must read " DOT_CHAR
+                       "netrc for user name and password",
+  "     --netrc-optional  Use either " DOT_CHAR "netrc or URL; overrides -n",
   "     --netrc-file FILE  Specify FILE for netrc",
   " -:  --next          "
   "Allows the following URL to use a separate set of options",


### PR DESCRIPTION
- On Windows get the home directory from the USERPROFILE environment variable when HOME is not defined.

- Change the documentation to clarify that the netrc filename on Windows is _netrc if not a POSIX-only build.

- Change the help text to show _netrc when it's expected instead of .netrc.

---

libcurl searches for netrc in the `HOME` directory if no directory is specified but in Windows `HOME` isn't typically defined unless running in a POSIX shell. I wrote this commit to check `USERPROFILE` for the home directory in Windows when `HOME` is not defined.

I'm on the fence about it though only because it's different from how the curl tool [currently searches for curlrc](http://curl.haxx.se/docs/manpage.html#-K):

> 1) curl tries to find the "home dir": It first checks for the CURL_HOME and then the HOME environment variables. Failing that, it uses getpwuid() on Unix-like systems (which returns the home dir given the current user in your system). On Windows, it then checks for the APPDATA variable, or as a last resort the '%USERPROFILE%\Application Data'.
> 
> 2) On windows, if there is no _curlrc file in the home dir, it checks for one in the same dir the curl executable is placed. On Unix-like systems, it will simply try to load .curlrc from the determined home dir. 

netrc is more generic of course but I wonder if it should have that same behavior. I decided against it and wrote this commit but really I don't know. Something else to consider is currently that functionality is only in the tool. I don't want to make things more complex but my goal here is something should be done to make netrc findable in Windows without having to specify a full path. If anyone has feedback on this PR please let me know, I won't commit this myself without a +1.