### PR TITLE
Fixed iphost.c unintended destruction of hash table and added unit1602 for hash.c

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -126,7 +126,7 @@ int Curl_conncache_init(struct conncache *connc, int size)
 void Curl_conncache_destroy(struct conncache *connc)
 {
   if(connc)
-    Curl_hash_clean(&connc->hash);
+    Curl_hash_destroy(&connc->hash);
 }
 
 /* returns an allocated key to find a bundle for this connection */

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -212,8 +212,11 @@ Curl_hash_apply(curl_hash *h, void *user,
 }
 #endif
 
+/* Destroys all the entries in the given hash and resets its attributes,
+ * prepping the given hash for [static|dynamic] deallocation.
+ */
 void
-Curl_hash_clean(struct curl_hash *h)
+Curl_hash_destroy(struct curl_hash *h)
 {
   int i;
 
@@ -227,6 +230,17 @@ Curl_hash_clean(struct curl_hash *h)
   h->slots = 0;
 }
 
+/* Removes all the entries in the given hash.
+ *
+ * @unittest: 1602
+ */
+void
+Curl_hash_clean(struct curl_hash *h)
+{
+  Curl_hash_clean_with_criterium(h, NULL, NULL);
+}
+
+/* Cleans all entries that pass the comp function criteria. */
 void
 Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
                                int (*comp)(void *, void *))
@@ -246,7 +260,7 @@ Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
       struct curl_hash_element *he = le->ptr;
       lnext = le->next;
       /* ask the callback function if we shall remove this entry or not */
-      if(comp(user, he->ptr)) {
+      if(comp == NULL || comp(user, he->ptr)) {
         Curl_llist_remove(list, le, (void *) h);
         --h->size; /* one less entry in the hash now */
       }

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -80,6 +80,7 @@ void *Curl_hash_pick(struct curl_hash *, void * key, size_t key_len);
 void Curl_hash_apply(struct curl_hash *h, void *user,
                      void (*cb)(void *user, void *ptr));
 int Curl_hash_count(struct curl_hash *h);
+void Curl_hash_destroy(struct curl_hash *h);
 void Curl_hash_clean(struct curl_hash *h);
 void Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
                                     int (*comp)(void *, void *));

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -137,7 +137,7 @@ struct curl_hash *Curl_global_host_cache_init(void)
 void Curl_global_host_cache_dtor(void)
 {
   if(host_cache_initialized) {
-    Curl_hash_clean(&hostname_cache);
+    Curl_hash_destroy(&hostname_cache);
     host_cache_initialized = 0;
   }
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -326,8 +326,8 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
 
   error:
 
-  Curl_hash_clean(&multi->sockhash);
-  Curl_hash_clean(&multi->hostcache);
+  Curl_hash_destroy(&multi->sockhash);
+  Curl_hash_destroy(&multi->hostcache);
   Curl_conncache_destroy(&multi->conn_cache);
   Curl_close(multi->closure_handle);
   multi->closure_handle = NULL;
@@ -1865,7 +1865,7 @@ CURLMcode curl_multi_cleanup(CURLM *multi_handle)
       Curl_close(multi->closure_handle);
     }
 
-    Curl_hash_clean(&multi->sockhash);
+    Curl_hash_destroy(&multi->sockhash);
     Curl_conncache_destroy(&multi->conn_cache);
     Curl_llist_destroy(multi->msglist, NULL);
     Curl_llist_destroy(multi->pending, NULL);
@@ -1888,7 +1888,7 @@ CURLMcode curl_multi_cleanup(CURLM *multi_handle)
       data = nextdata;
     }
 
-    Curl_hash_clean(&multi->hostcache);
+    Curl_hash_destroy(&multi->hostcache);
 
     /* Free the blacklists by setting them to NULL */
     Curl_pipeline_set_site_blacklist(NULL, &multi->pipelining_site_bl);

--- a/lib/share.c
+++ b/lib/share.c
@@ -188,7 +188,7 @@ curl_share_cleanup(CURLSH *sh)
     return CURLSHE_IN_USE;
   }
 
-  Curl_hash_clean(&share->hostcache);
+  Curl_hash_destroy(&share->hostcache);
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   Curl_cookie_cleanup(share->cookies);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -155,7 +155,7 @@ test1520 \
 \
 test1525 test1526 test1527 test1528 test1529 \
 \
-test1600 test1601 \
+test1600 test1601 test1602 \
 \
 test1800 test1801 \
 \

--- a/tests/data/test1602
+++ b/tests/data/test1602
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+hash
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+Internal hash create/add/destroy testing, exercising clean functions
+ </name>
+<tool>
+unit1602
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -7,7 +7,7 @@ UNITFILES = curlcheck.h \
 # These are all unit test programs
 UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307	\
  unit1308 unit1309 unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
- unit1600 unit1601
+ unit1600 unit1601 unit1602
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -62,4 +62,7 @@ unit1600_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1601_SOURCES = unit1601.c $(UNITFILES)
 unit1601_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1602_SOURCES = unit1602.c $(UNITFILES)
+unit1602_CPPFLAGS = $(AM_CPPFLAGS)
 

--- a/tests/unit/unit1305.c
+++ b/tests/unit/unit1305.c
@@ -67,7 +67,7 @@ static void unit_stop( void )
     free(data_node);
   }
   free(data_key);
-  Curl_hash_clean(&hp);
+  Curl_hash_destroy(&hp);
 
   curl_easy_cleanup(data);
   curl_global_cleanup();

--- a/tests/unit/unit1602.c
+++ b/tests/unit/unit1602.c
@@ -1,0 +1,80 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2011, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#define ENABLE_CURLX_PRINTF
+#include "curlx.h"
+
+#include "hash.h"
+
+#include "memdebug.h" /* LAST include file */
+
+ static CURLcode unit_setup( void )
+{
+  return CURLE_OK;
+}
+
+static void unit_stop( void )
+{
+
+}
+
+static void mydtor(void *p)
+{
+  int *ptr = (int*)p;
+  free(ptr);
+}
+
+UNITTEST_START
+  int *value;
+  int *value2;
+  size_t klen = sizeof(int);
+
+  struct curl_hash hash_static;
+  int key = 20;
+  int key2 = 25;
+  int rc = 0;
+
+  rc = Curl_hash_init(&hash_static, 7, Curl_hash_str,
+                        Curl_str_key_compare, mydtor);
+
+  if(rc)
+  {
+    fail("Curl_hash_init failed to initialize static hash!");
+    goto unit_test_abort;
+  }
+
+  value = malloc(sizeof(int));
+  value2 = malloc(sizeof(int));
+
+  *value = 199;
+  *value2 = 204;
+  Curl_hash_add(&hash_static, &key, klen, value);
+  
+  Curl_hash_clean(&hash_static);
+
+  /* Attempt to add another key/value pair */
+  Curl_hash_add(&hash_static, &key2, klen, value2);
+
+  Curl_hash_destroy(&hash_static);
+  
+UNITTEST_STOP


### PR DESCRIPTION
Added unit1602 which exposes a bug in hash.c `Curl_hash_clean` function. Test currently fails because of a Floating point exception in the hash compare function `Curl_hash_str` due to `slots_num`being reset by `Curl_hash_clean` prior to attempting to add another key/value pair with `Curl_hash_add`.