### PR TITLE
Require nghttp2 v1.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2841,7 +2841,9 @@ if test X"$want_h2" != Xno; then
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
 
-    AC_CHECK_LIB(nghttp2, nghttp2_session_callbacks_set_send_callback,
+    # use nghttp2_option_set_no_recv_client_magic to require nghttp2
+    # >= 1.0.0
+    AC_CHECK_LIB(nghttp2, nghttp2_option_set_no_recv_client_magic,
       [
        AC_CHECK_HEADERS(nghttp2/nghttp2.h,
           curl_h2_msg="enabled (nghttp2)"


### PR DESCRIPTION
This commit requires nghttp2 v1.0.0 to compile, and migrate to v1.0.0,
and utilize recent version of nghttp2 to simplify the code,

First we use nghttp2_option_set_no_recv_client_magic function to
detect nghttp2 v1.0.0.  That function only exists since v1.0.0.

Since nghttp2 v0.7.5, nghttp2 ensures header field ordering, and
validates received header field.  If it found error, RST_STREAM with
PROTOCOL_ERROR is issued.  Since we require v1.0.0, we can utilize
this feature to simplify libcurl code.  This commit does this.

Migration from 0.7 series are done based on nghttp2 migration
document.  For libcurl, we removed the code sending first 24 bytes
client magic.  It is now done by nghttp2 library.
on_invalid_frame_recv callback signature changed, and is updated
accordingly.