### PR TITLE
gtls: don't fail on non-fatal alerts during handshake

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -327,7 +327,8 @@ static CURLcode handshake(struct connectdata *conn,
       if(strerr == NULL)
         strerr = gnutls_strerror(rc);
 
-      failf(data, "gnutls_handshake() warning: %s", strerr);
+      infof(data, "gnutls_handshake() warning: %s\n", strerr);
+      continue;
     }
     else if(rc < 0) {
       const char *strerr = NULL;


### PR DESCRIPTION
Stop curl from failing when non-fatal alert is received during handshake.
This e.g. fixes lots of problems when working with https sites through proxies.