### PR TITLE
Makefile.m32: add support for CURL_LDFLAG_EXTRAS

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -58,7 +58,7 @@ CC	= $(CROSSPREFIX)gcc
 CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
-LDFLAGS	= -s
+LDFLAGS	= $(CURL_LDFLAG_EXTRAS) -s
 AR	= $(CROSSPREFIX)ar
 RANLIB	= $(CROSSPREFIX)ranlib
 RC	= $(CROSSPREFIX)windres


### PR DESCRIPTION
It is similar to existing `CURL_CFLAG_EXTRAS`, but for 
extra linker options.