### PR TITLE
tests: Distribute CMakeLists.txt files in subdirectories

### DIFF
--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -5,7 +5,7 @@ test:
 # TESTCASES are taken from Makefile.inc
 include Makefile.inc
 
-EXTRA_DIST = $(TESTCASES) DISABLED
+EXTRA_DIST = $(TESTCASES) DISABLED CMakeLists.txt
 
 filecheck:
 	@mkdir test-place; \

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -51,7 +51,7 @@ AM_CPPFLAGS = -I$(top_builddir)/include/curl \
 endif
 
 EXTRA_DIST = test75.pl test307.pl test610.pl test613.pl test1013.pl	\
-test1022.pl Makefile.inc notexists.pl
+test1022.pl Makefile.inc notexists.pl CMakeLists.txt
 
 CFLAG_CURL_SYMBOL_HIDING = @CFLAG_CURL_SYMBOL_HIDING@
 

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -60,5 +60,5 @@ endif
 # Makefile.inc provides neat definitions
 include Makefile.inc
 
-EXTRA_DIST = base64.pl Makefile.inc
+EXTRA_DIST = base64.pl Makefile.inc CMakeLists.txt
 


### PR DESCRIPTION
These are not present in the current source releases, breaking building with cmake.

See https://github.com/bagder/curl/issues/326