### PR TITLE
Re-enable static library compilation with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1111,7 +1111,7 @@ set(ENABLE_SHARED           "yes")
 if(CURL_STATICLIB)
   # Broken: LIBCURL_LIBS below; .a lib is not built
   message(WARNING "Static linking is broken!")
-  set(ENABLE_STATIC         "no")
+  set(ENABLE_STATIC         "yes")
 else()
   set(ENABLE_STATIC         "no")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1111,6 +1111,7 @@ set(ENABLE_SHARED           "yes")
 if(CURL_STATICLIB)
   # Broken: LIBCURL_LIBS below; .a lib is not built
   message(WARNING "Static linking is broken!")
+  set(ENABLE_SHARED         "no")
   set(ENABLE_STATIC         "yes")
 else()
   set(ENABLE_STATIC         "no")


### PR DESCRIPTION
It's a really small thing, but the `libcurl.a` compilation works fine with CMake in a lot of cases provided this restriction is removed. It doesn't make too much sense to completely disable the static build just because something might not quite work correctly.