### PR TITLE
openssl: work around MSVC warning

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1492,7 +1492,7 @@ static void ssl_tls_trace(int direction, int ssl_ver, int content_type,
   char ssl_buf[1024];
   char unknown[32];
   int msg_type, txt_len;
-  const char *verstr;
+  const char *verstr = NULL;
   struct connectdata *conn = userp;
 
   if(!conn || !conn->data || !conn->data->set.fdebug ||


### PR DESCRIPTION
MSVC 12 complains:
lib\vtls\openssl.c(1554): warning C4701: potentially uninitialized local variable 'verstr' used
It's a false positive, but as it's normally not, I have enabled warning-as-error for that warning.