### PR TITLE
Add `--proto-default` option

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -1314,6 +1314,11 @@ Tells curl to use the listed protocols after a redirect. See --proto for
 how protocols are represented.
 
 (Added in 7.20.2)
+.IP "--proto-default <protocol>"
+When curl is given a URL without any protocol ("example.com" instead of
+"http://example.com"), it will guess the protocol from the hostname,
+defaulting to "http". This option tells curl to instead use the given protocol
+with every such unspecified URL.
 .IP "--proxy-anyauth"
 Tells curl to pick a suitable authentication method when communicating with
 the given proxy. This might cause an extra request/response round-trip. (Added

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1645,6 +1645,9 @@ typedef enum {
   /* Wait/don't wait for pipe/mutex to clarify */
   CINIT(PIPEWAIT, LONG, 237),
 
+  /* Set the protocol used when curl is given a URL without a protocol */
+  CINIT(DEFAULT_PROTOCOL, OBJECTPOINT, 238),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1350,6 +1350,7 @@ enum dupstring {
   STRING_COOKIE,          /* HTTP cookie string to send */
   STRING_COOKIEJAR,       /* dump all cookies to this file */
   STRING_CUSTOMREQUEST,   /* HTTP/FTP/RTSP request/method to use */
+  STRING_DEFAULT_PROTOCOL, /* Protocol to use when the URL doesn't specify */
   STRING_DEVICE,          /* local network interface/address to use */
   STRING_ENCODING,        /* Accept-Encoding string */
   STRING_FTP_ACCOUNT,     /* ftp account data */

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -40,6 +40,7 @@ void config_init(struct OperationConfig* config)
                         ~(CURLPROTO_FILE | CURLPROTO_SCP | CURLPROTO_SMB |
                           CURLPROTO_SMBS);
   config->proto_redir_present = FALSE;
+  config->proto_default = NULL;
 }
 
 static void free_config_fields(struct OperationConfig *config)

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -51,6 +51,7 @@ struct OperationConfig {
   bool proto_present;
   long proto_redir;
   bool proto_redir_present;
+  char* proto_default;
   curl_off_t resume_from;
   char *postfields;
   curl_off_t postfieldsize;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -169,6 +169,7 @@ static const struct LongShort aliases[]= {
   {"$C", "ftp-pret",                 FALSE},
   {"$D", "proto",                    TRUE},
   {"$E", "proto-redir",              TRUE},
+  {"$U", "proto-default",            TRUE},
   {"$F", "resolve",                  TRUE},
   {"$G", "delegation",               TRUE},
   {"$H", "mail-auth",                TRUE},
@@ -940,6 +941,12 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
         config->proto_redir_present = TRUE;
         if(proto2num(config, &config->proto_redir, nextarg))
           return PARAM_BAD_USE;
+        break;
+      case 'U': /* --proto-default */
+        GetStr(&config->proto_default, nextarg);
+        err = check_protocol(config->proto_default);
+        if(err)
+          return err;
         break;
       case 'F': /* --resolve */
         err = add2list(&config->resolve, nextarg);

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -166,6 +166,7 @@ static const char *const helptext[] = {
   " -#, --progress-bar  Display transfer progress as a progress bar",
   "     --proto PROTOCOLS  Enable/disable PROTOCOLS",
   "     --proto-redir PROTOCOLS  Enable/disable PROTOCOLS on redirect",
+  "     --proto-default PROTOCOL Protocol used when not supplied by the URL",
   " -x, --proxy [PROTOCOL://]HOST[:PORT]  Use proxy on given port",
   "     --proxy-anyauth  Pick \"any\" proxy authentication method (H)",
   "     --proxy-basic   Use Basic authentication on the proxy (H)",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1290,6 +1290,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           my_setopt_flags(curl, CURLOPT_PROTOCOLS, config->proto);
         if(config->proto_redir_present)
           my_setopt_flags(curl, CURLOPT_REDIR_PROTOCOLS, config->proto_redir);
+        my_setopt_str(curl, CURLOPT_DEFAULT_PROTOCOL,
+                      config->proto_default);
 
         if(config->content_disposition
            && (urlnode->flags & GETOUT_USEREMOTE)

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -339,6 +339,26 @@ long proto2num(struct OperationConfig *config, long *val, const char *str)
 }
 
 /**
+ * Check that the given string is a protocol known to curl
+ *
+ * @param str the string to inspect
+ * @return PARAM_OK if the string is a known protocol, else an error code
+ */
+int check_protocol(const char *str)
+{
+  const char * const *pp;
+  const curl_version_info_data *curlinfo = curl_version_info(CURLVERSION_NOW);
+  if(!str)
+    return PARAM_REQUIRES_PARAMETER;
+  for(pp = curlinfo->protocols; *pp; pp++) {
+    if(strcmp(*pp, str) == 0) {
+      return PARAM_OK;
+    }
+  }
+  return PARAM_BAD_USE;
+}
+
+/**
  * Parses the given string looking for an offset (which may be a
  * larger-than-integer value). The offset CANNOT be negative!
  *

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -37,6 +37,7 @@ ParameterError str2double(double *val, const char *str);
 ParameterError str2udouble(double *val, const char *str);
 
 long proto2num(struct OperationConfig *config, long *val, const char *str);
+int check_protocol(const char *str);
 
 ParameterError str2offset(curl_off_t *val, const char *str);
 
@@ -51,4 +52,3 @@ int ftpcccmethod(struct OperationConfig *config, const char *str);
 long delegation(struct OperationConfig *config, char *str);
 
 #endif /* HEADER_CURL_TOOL_PARAMHLP_H */
-

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -68,6 +68,7 @@ extern const NameValueUnsigned setopt_nv_CURLAUTH[];
 #define setopt_nv_CURLOPT_NETRC setopt_nv_CURL_NETRC
 #define setopt_nv_CURLOPT_PROTOCOLS setopt_nv_CURLPROTO
 #define setopt_nv_CURLOPT_REDIR_PROTOCOLS setopt_nv_CURLPROTO
+#define setopt_nv_CURLOPT_DEFAULT_PROTOCOL setopt_nv_CURLPROTO
 #define setopt_nv_CURLOPT_PROXYTYPE setopt_nv_CURLPROXY
 #define setopt_nv_CURLOPT_PROXYAUTH setopt_nv_CURLAUTH
 


### PR DESCRIPTION
This modifies the protocol-guessing algorithm to respect
the available protocols. For example:
* `curl --proto -ftp ftp.gnu.org` does not consider FTP as the protocol (instead it will try HTTP)
* `curl --proto '=https' www.gnu.org` will try HTTPS

The impetus here is that I want to be able to get an HTTPS connection when I have a scheme-less URL. 

I'm not sure if --proto was the right option to go after here, but like that this stops curl from selecting a disallowed protocol and then complaining about it.