### PR TITLE
schannel: compile fix for Windows SDK 8+

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1129,9 +1129,11 @@ cleanup:
     osver.dwMajorVersion = 5;
     osver.dwMinorVersion = 0;
     versionMask = VerSetConditionMask(0, VER_MAJORVERSION, VER_EQUAL);
-    versionMask = VerSetConditionMask(versionMask, VER_MINORVERSION, VER_EQUAL);
+    versionMask = VerSetConditionMask(versionMask, VER_MINORVERSION,
+                                      VER_EQUAL);
 
-    if(VerifyVersionInfo(&osver, VER_MAJORVERSION | VER_MINORVERSION, versionMask))
+    if(VerifyVersionInfo(&osver, VER_MAJORVERSION | VER_MINORVERSION,
+                         versionMask))
       isWin2k = TRUE;
 
     if(isWin2k && sspi_status == SEC_E_OK)


### PR DESCRIPTION
GetVersion was deprecated in Windows SDK 8.0, which is treated as an error by default. This has been cleaned up in connect.c and curl_sspi.c, but https://github.com/bagder/curl/commit/3e7ec1e8492824f0c6f6dea718624935a1407069 re-introduced a call to GetVersion.
As in the other places where GetVersion(Ex) was used, this can be changed to use VerifyVersionInfo, which is not deprecated. I don't think a fallback version for Windows < 2000 is necessary here as SChannel was introduced in Windows 2000.