### PR TITLE
configure: Add new --disable-rt option

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1851,8 +1851,10 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC], [
   AC_REQUIRE([AC_HEADER_TIME])dnl
   AC_CHECK_HEADERS(sys/types.h sys/time.h time.h)
   AC_MSG_CHECKING([for monotonic clock_gettime])
-  AC_COMPILE_IFELSE([
-    AC_LANG_PROGRAM([[
+  #
+  if test "x$dontwant_rt" == "xno" ; then
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1866,17 +1868,18 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC], [
 #include <time.h>
 #endif
 #endif
-    ]],[[
-      struct timespec ts;
-      (void)clock_gettime(CLOCK_MONOTONIC, &ts);
-    ]])
-  ],[
-    AC_MSG_RESULT([yes])
-    ac_cv_func_clock_gettime="yes"
-  ],[
-    AC_MSG_RESULT([no])
-    ac_cv_func_clock_gettime="no"
-  ])
+      ]],[[
+        struct timespec ts;
+        (void)clock_gettime(CLOCK_MONOTONIC, &ts);
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      ac_cv_func_clock_gettime="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      ac_cv_func_clock_gettime="no"
+    ])
+  fi
   dnl Definition of HAVE_CLOCK_GETTIME_MONOTONIC is intentionally postponed
   dnl until library linking and run-time checks for clock_gettime succeed.
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,7 @@ CURL_CHECK_OPTION_WERROR
 CURL_CHECK_OPTION_CURLDEBUG
 CURL_CHECK_OPTION_SYMBOL_HIDING
 CURL_CHECK_OPTION_ARES
+CURL_CHECK_OPTION_RT
 
 XC_CHECK_PATH_SEPARATOR
 
@@ -3217,7 +3218,7 @@ if test "x$want_thres" = xyes && test "x$want_ares" = xyes; then
 [Options --enable-threaded-resolver and --enable-ares are mutually exclusive])
 fi
 
-if test "$want_thres" = "yes"; then
+if test "$want_thres" = "yes" && test "$dontwant_rt" = "no"; then
   AC_CHECK_HEADER(pthread.h,
     [ AC_DEFINE(HAVE_PTHREAD_H, 1, [if you have <pthread.h>])
       save_CFLAGS="$CFLAGS"

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -316,6 +316,42 @@ dnl     AC_MSG_ERROR([options --enable-ares and --enable-threads are mutually ex
 dnl   fi
 dnl ])
 
+dnl CURL_CHECK_OPTION_RT
+dnl -------------------------------------------------
+dnl Verify if configure has been involed with option
+dnl --disable-rt and set shell variable dontwant_rt
+dnl as appropriate.
+
+AC_DEFUN([CURL_CHECK_OPTION_RT], [
+  AC_BEFORE([$0], [CURL_CHECK_LIB_THREADS])dnl
+  AC_MSG_CHECKING([whether to disable dependency on -lrt])
+  OPT_RT="default"
+  AC_ARG_ENABLE(rt,
+ AC_HELP_STRING([--disable-rt],[disable dependency on -lrt]),
+  OPT_RT=$enableval)
+  case "$OPT_RT" in
+    no)
+      dnl --disable-rt used (reverse logic)
+      dontwant_rt="yes"
+      AC_MSG_RESULT([yes])
+      ;;
+    default)
+      dnl configure option not specified (so not disabled)
+      dontwant_rt="no"
+      AC_MSG_RESULT([(assumed no)]
+      ;;
+    *)
+      dnl --enable-rt option used (reverse logic)
+      dontwant_rt="no"
+      AC_MSG_RESULT([no])
+      ;;
+  esac
+  dnl TODO: may require mutual exclusion
+  if test "$dontwant_rt" = "yes" && test "$want_thres" = "yes" ; then
+    AC_MSG_ERROR([options --disable-rt and --enable-thread-resolver are mutually exclusive, at most one can be selected.])
+  fi
+])
+ 
 
 dnl CURL_CHECK_OPTION_WARNINGS
 dnl -------------------------------------------------


### PR DESCRIPTION
This option is intended to disable any attempts in configure to create dependency on stuff requiring linking to `librt.so` and `libpthread.so`, in this case it means `clock_gettime(CLOCK_MONOTONIC, &mt)`. Most of changes are self-explanatory, but the idea is to prevent `configure` from checking if `CLOCK_MONOTONIC` can be used. That automatically prevents checks if `-lrt` can be added to `LDFLAGS`.

The reason why I'm suggesting such changes is the portability issue. We were in need to build curl which doesn't link `libpthread.so` to avoid the following bug: https://sourceware.org/bugzilla/show_bug.cgi?id=16628.

This new option must be used with LDAP support disabled, because `libldap_r.so` that is linked into curl links `librt.so` and `libpthread.so`, so then `libcurl.so` ends up with them linked.