### PR TITLE
Handle gracefully scenarios where NTLM auth persist only for a single…

### DIFF
--- a/lib/curl_ntlm.c
+++ b/lib/curl_ntlm.c
@@ -84,7 +84,11 @@ CURLcode Curl_input_ntlm(struct connectdata *conn,
       ntlm->state = NTLMSTATE_TYPE2; /* We got a type-2 message */
     }
     else {
-      if(ntlm->state == NTLMSTATE_TYPE3) {
+      if(ntlm->state == NTLMSTATE_LAST) {
+        infof(conn->data, "NTLM auth restarted\n");
+        Curl_http_ntlm_cleanup(conn);
+      }
+      else if(ntlm->state == NTLMSTATE_TYPE3) {
         infof(conn->data, "NTLM handshake rejected\n");
         Curl_http_ntlm_cleanup(conn);
         ntlm->state = NTLMSTATE_NONE;
@@ -211,6 +215,9 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
   case NTLMSTATE_TYPE3:
     /* connection is already authenticated,
      * don't send a header in future requests */
+    ntlm->state = NTLMSTATE_LAST;
+
+  case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;
     break;


### PR DESCRIPTION
… request

Currently when the server responds with 401 on NTLM authenticated connection (re-used)
we consider authentication to have failed.
However this is legitimate and may happen when for example IIS is set configured to
'authPersistSingleRequest' or when the request goes thru a proxy (with 'via' header).

Implemented by imploying an additional state once a connection is re-used to indicate
that if we receive 401 we need to restart authentication.

----

It is a new approach instead of what I've suggested at PR #250 (detailed there).

Link to MS doc about 'authPersistSingleRequest':
https://msdn.microsoft.com/en-us/library/aa347472(v=VS.90).aspx

Link to MS blog explaining why this may occur when using proxy:
http://blogs.technet.com/b/isablog/archive/2009/07/30/excessive-authentication-traffic-accessing-an-iis-site-when-using-isa-server-2006-as-forward-proxy.aspx

Thanks,
Isaac B.