### PR TITLE
Remove SessionHandle from streamsh hash in Curl_http_done.

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1443,7 +1443,7 @@ CURLcode Curl_http_done(struct connectdata *conn,
                         CURLcode status, bool premature)
 {
   struct SessionHandle *data = conn->data;
-  struct HTTP *http =data->req.protop;
+  struct HTTP *http = data->req.protop;
 
   Curl_unencode_cleanup(conn);
 
@@ -1481,6 +1481,11 @@ CURLcode Curl_http_done(struct connectdata *conn,
     }
     free(http->push_headers);
     http->push_headers = NULL;
+  }
+  if(http->stream_id) {
+    Curl_hash_delete(&conn->proto.httpc.streamsh,
+                     &http->stream_id, sizeof(http->stream_id));
+    http->stream_id = 0;
   }
 #endif
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -404,7 +404,7 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
          internal error more than anything else! */
       failf(conn->data, "Received frame on Stream ID: %x not in stream hash!",
             stream_id);
-      return NGHTTP2_ERR_CALLBACK_FAILURE;
+      return 0;
     }
     stream = data_s->req.protop;
     if(!stream) {


### PR DESCRIPTION
Return 0 instead of NGHTTP2_ERR_CALLBACK_FAILURE if we can't locate the
SessionHandle. Apparently mod_h2 will sometimes send a frame for a
stream_id we're finished with.