### PR TITLE
curl_multi_add_handle.3: fix a typo

### DIFF
--- a/docs/libcurl/curl_multi_add_handle.3
+++ b/docs/libcurl/curl_multi_add_handle.3
@@ -31,7 +31,7 @@ CURLMcode curl_multi_add_handle(CURLM *multi_handle, CURL *easy_handle);
 Adds a standard easy handle to the multi stack. This function call will make
 this \fImulti_handle\fP control the specified \fIeasy_handle\fP.
 
-While an easy handle is added to a multi stack, you can not and you must not
+While an easy handle is added to a multi stack, you cannot and you must not
 use \fIcurl_easy_perform(3)\fP on that handle. After having removed the easy
 handle from the multi stack again, it is perfectly fine to use it with the
 easy interface again.


### PR DESCRIPTION
"can not" => "cannot"