### PR TITLE
travis.yml: Add OS X testbot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
+os:
+  - linux
+  - osx
+
+sudo: true
+
 language: c
+
+install:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update > /dev/null; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl libidn rtmpdump libssh2 c-ares libmetalink libressl nghttp2; fi
 
 before_script:
   - ./buildconf


### PR DESCRIPTION
Hi all,

This patch try to add OS X building on Travis CI.

curl is also widely used on OS X and Travis CI has supported OS X system. So I think it won't harm to add it into our curl tree.

Before merge this patch, we need enable multi-os feature on our curl repo on Travis CI.  To enable this feature, owner of the repo need to sent an email to support@travis-ci.com:
http://docs.travis-ci.com/user/multi-os/

I have create a demo here: https://travis-ci.org/wine-zh/curl/builds/75475788

Unfortunately, there is a test failure on OS X, see also: https://github.com/bagder/curl/issues/380

I'll be glad to improve this patch for curl, any advice is appreciated!
Thank you in advance! :-)