### PR TITLE
inet_pton.c: Fix MSVC run-time check failure

### DIFF
--- a/lib/inet_pton.c
+++ b/lib/inet_pton.c
@@ -189,7 +189,7 @@ inet_pton6(const char *src, unsigned char *dst)
       if(tp + INT16SZ > endp)
         return (0);
       *tp++ = (unsigned char) (val >> 8) & 0xff;
-      *tp++ = (unsigned char) val & 0xff;
+      *tp++ = (unsigned char) (val & 0xff);
       saw_xdigit = 0;
       val = 0;
       continue;


### PR DESCRIPTION
Visual Studio complains with a message box at run-time:
"Run-Time Check Failure #1 - A cast to a smaller data type has caused a loss of data.
If this was intentional, you should mask the source of the cast with the appropriate bitmask.
For example:
char c = (i & 0xFF);
Changing the code in this way will not affect the quality of the resulting optimized code."

This is because only 'val' is cast to unsigned char, so the "& 0xff" has no effect.