### PR TITLE
openssl: don't fail if no server cert is presented and strict checking is disabled

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2644,8 +2644,10 @@ static CURLcode servercert(struct connectdata *conn,
 
   connssl->server_cert = SSL_get_peer_certificate(connssl->handle);
   if(!connssl->server_cert) {
-    if(strict)
-      failf(data, "SSL: couldn't get peer certificate!");
+    if(!strict)
+      return CURLE_OK;
+
+    failf(data, "SSL: couldn't get peer certificate!");
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 


### PR DESCRIPTION
If strict certificate checking is disabled (CURLOPT_SSL_VERIFYPEER and/or
CURLOPT_SSL_VERIFYHOST are disabled) do not fail if the server doesn't
present a certificate at all.

Also see discussion at https://github.com/frenche/curl/commit/84a400ffd745dd7941b5bd0a2075ecd098ef608e#commitcomment-12826078