### PR TITLE
curl_easy_{escape,setopt}.3: fix example

### DIFF
--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -49,7 +49,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   char *output = curl_easy_escape(curl, "data to convert", 15);
   if(output) {
-    printf("Encoded: %s\n", output);
+    printf("Encoded: %s\en", output);
     curl_free(output);
   }
 }

--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -52,7 +52,7 @@ if(curl) {
     printf("Encoded: %s\n", output);
     curl_free(output);
   }
-}}
+}
 .fi
 .SH "SEE ALSO"
 .BR curl_easy_unescape "(3), " curl_free "(3), " RFC 3986

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -529,7 +529,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
   res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
-}}
+}
 .fi
 .SH "SEE ALSO"
 .BR curl_easy_init "(3), " curl_easy_cleanup "(3), " curl_easy_reset "(3), "


### PR DESCRIPTION
remove redundant '}'