### PR TITLE
libcurl.m4: Put braces around empty if body

### DIFF
--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -178,7 +178,7 @@ x=CURLOPT_WRITEDATA;
 x=CURLOPT_ERRORBUFFER;
 x=CURLOPT_STDERR;
 x=CURLOPT_VERBOSE;
-if (x) ;
+if (x) {;}
 ]])],libcurl_cv_lib_curl_usable=yes,libcurl_cv_lib_curl_usable=no)
 
            CPPFLAGS=$_libcurl_save_cppflags


### PR DESCRIPTION
Put braces around empty "if" body in libcurl.m4 check to avoid warning:

        suggest braces around empty body in an 'if' statement

and make it work with -Werror builds.