### PR TITLE
Close connection when DNS entry is removed from cache

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1648,6 +1648,9 @@ typedef enum {
   /* Set the protocol used when curl is given a URL without a protocol */
   CINIT(DEFAULT_PROTOCOL, OBJECTPOINT, 238),
 
+  /* Resolve dns earlier in connection creation */
+  CINIT(DNS_RESOLVE_FIRST, LONG, 239),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -702,6 +702,9 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
   case CURLOPT_DNS_CACHE_TIMEOUT:
     data->set.dns_cache_timeout = va_arg(param, long);
     break;
+  case CURLOPT_DNS_RESOLVE_FIRST:
+    data->set.dns_resolve_first = va_arg(param, long);
+    break;
   case CURLOPT_DNS_USE_GLOBAL_CACHE:
     /* remember we want this enabled */
     arg = va_arg(param, long);
@@ -3204,6 +3207,20 @@ ConnectionExists(struct SessionHandle *data,
           if(!check->ip_addr_str[0]) {
             infof(data,
                   "Connection #%ld is still name resolving, can't reuse\n",
+                  check->connection_id);
+            continue;
+          }
+        }
+
+        /* Unable to get ip address from needle...
+         * Is this possible?
+         */
+        if(data->set.dns_resolve_first) {
+          if(!check->ip_addr_str[0] &&
+             (strcmp(needle->ip_addr_str, check->ip_addr_str) != 0)) {
+            infof(data, "#%s #%s\n", needle->dns_entry->addr->ai_canonname,
+                  check->ip_addr_str);
+            infof(data, "Connection #%ld has stale ip, can't reuse\n",
                   check->connection_id);
             continue;
           }
@@ -5718,8 +5735,10 @@ static CURLcode create_conn(struct SessionHandle *data,
      we only acknowledge this option if this is not a re-used connection
      already (which happens due to follow-location or during a HTTP
      authentication phase). */
-  if(data->set.reuse_fresh && !data->state.this_is_a_follow)
+  if((data->set.reuse_fresh && !data->state.this_is_a_follow) ||
+          data->set.dns_resolve_first) {
     reuse = FALSE;
+  }
   else
     reuse = ConnectionExists(data, conn, &conn_temp, &force_reuse, &waitpipe);
 
@@ -5994,6 +6013,41 @@ CURLcode Curl_connect(struct SessionHandle *data,
       /* DNS resolution is done: that's either because this is a reused
          connection, in which case DNS was unnecessary, or because DNS
          really did finish already (synch resolver/fast async resolve) */
+
+      /*
+       * Since DNS is resolved, we can check what IP has been resolved
+       * in new connection against existing connections to see if one
+       * can be reused.
+       */
+      if(data->set.dns_resolve_first) {
+        bool force_reuse = FALSE;
+        bool waitpipe = FALSE;
+        struct connectdata *usethis = NULL;
+        bool reuse;
+
+        reuse = ConnectionExists(data, *in_connect, &usethis,
+                                  &force_reuse, &waitpipe);
+
+        if(reuse) {
+          // Connection found that can be used, we need to free old connection
+          struct connectdata *new_conn = NULL;
+
+          new_conn = *in_connect;
+          *in_connect = usethis;
+
+          // Remove new connection from cache
+          Curl_disconnect(new_conn, TRUE);
+
+          /* How can we reuse old connection? */
+          infof(data, "CONNECTION REUSED\n");
+//          conn_free(*in_connect);
+//          infof(data, "COPY OLD CONN TO NEW CONNECTION\n");
+//          reuse_conn(usethis, *in_connect);
+//          infof(data, "FREE OLD CONNECTION\n");
+//          conn_free(usethis);
+        }
+      }
+
       result = Curl_setup_conn(*in_connect, protocol_done);
     }
   }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1518,6 +1518,7 @@ struct UserDefined {
   struct ssl_config_data ssl;  /* user defined SSL stuff */
   curl_proxytype proxytype; /* what kind of proxy that is in use */
   long dns_cache_timeout; /* DNS cache timeout */
+  long dns_resolve_first; /* Resolve dns first in create connection */
   long buffer_size;      /* size of receive buffer to use */
   void *private_data; /* application-private data */
 


### PR DESCRIPTION
There are two fixes in this PR:

1) DNS_CACHE_TIMEOUT is not respected

We ran across an issue where DNS cache entry were never removed for reused connections, and this is fixed by commented out the if block in `resolve_server` in `multi.c`. This would cause DNS entries to be zapped, while still reusing the connection. The fix is only temporary and will be replaced with an appropriate check/fix.

2) Existing connections would not re-resolve DNS, even after cache has been cleared

Related to the previous fix, our solution was to mark the connection for closing when the DNS entry was cleared from the cache. Cache clear does not alter the current connection, and only closing the connection would force DNS resolution (by creating a new connection). This is more efficient than creating a new connection per request via the `CURL_FRESH_CONNECT`option.

This is a work in progress, and just wanted to get feedback on proposed changes. Will add tests/comments/whatever if necessary for merging it into mainline. I will also clean up the commits before merging. 

Thanks. 