### PR TITLE
Use HTTP2-compatible cipher as first preference

### DIFF
--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -114,7 +114,8 @@ bool Curl_ossl_cert_status_request(void);
 #define curlssl_cert_status_request() Curl_ossl_cert_status_request()
 
 #define DEFAULT_CIPHER_SELECTION \
-  "ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH"
+  "ECDHE-RSA-AES128-GCM-SHA256:" \
+  "ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4"
 
 #endif /* USE_OPENSSL */
 #endif /* HEADER_CURL_SSLUSE_H */


### PR DESCRIPTION
This is a follow up of https://sourceforge.net/p/curl/bugs/1487/ - 0d1060f21efe81454f59f75d12f2798ba0566130 did not solve this issue for me.
When connecting to [http2.golang.org](https://http2.golang.org/), OpenSSL advertises the following cipher suites after sorting ciphers with `@STRENGTH`:
![](https://maximilianhils.com/upload/2015-09/2015-09-02_17-53-48.png)

The go server apparently does not support `SHA384`. As a consequence, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)` will be picked, which is blacklisted by the HTTP2 spec. This causes the go server to fail the connection.

By listing ECDHE-RSA-AES128-GCM-SHA256 as the first preference, HTTP2 servers will always either pick that (HTTP2 servers must implement that cipher according to the spec) or the server preference, which should not be blacklisted by the HTTP2 spec. Unfortunately, `ECDHE-RSA-AES128-GCM-SHA256` is considered to be weaker by OpenSSL (`AES128` vs `AES256` I suppose), so we need to remove `@STRENGTH` again.

Test case: `curl --http2 https://http2.golang.org/`