### PR TITLE
inet_pton.c: Fix MSVC run-time check failure (2)

### DIFF
--- a/lib/inet_pton.c
+++ b/lib/inet_pton.c
@@ -206,7 +206,7 @@ inet_pton6(const char *src, unsigned char *dst)
     if(tp + INT16SZ > endp)
       return (0);
     *tp++ = (unsigned char) (val >> 8) & 0xff;
-    *tp++ = (unsigned char) val & 0xff;
+    *tp++ = (unsigned char) (val & 0xff);
   }
   if(colonp != NULL) {
     /*


### PR DESCRIPTION
This fixes another run-time check failure because of a narrowing cast on Visual C++.

Sorry, I forgot that one in #387.