### PR TITLE
cmake // IPv6 // disable Unix header check on Windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ option(DISABLED_THREADSAFE "Set to explicitly specify we don't want to use threa
 mark_as_advanced(DISABLED_THREADSAFE)
 option(ENABLE_IPV6 "Define if you want to enable IPv6 support" ON)
 mark_as_advanced(ENABLE_IPV6)
-if(ENABLE_IPV6)
+if(ENABLE_IPV6 AND NOT WIN32)
   include(CheckStructHasMember)
   check_struct_has_member("struct sockaddr_in6" sin6_addr "netinet/in.h"
                           HAVE_SOCKADDR_IN6_SIN6_ADDR)


### PR DESCRIPTION
Hello All!

I've removed "netinet/in.h" header check on Windows platform, since it absent.
Current check always failed leaving IPv6 support disabled in result build.

Build tested with MSVC++ 2013/MinGW gcc 5.1

@bradking could you please review?

Thank you.