### PR TITLE
Add Windows header for CRYPT_E_REVOKED macro

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -249,7 +249,7 @@
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
 #    ifdef HAVE_WS2TCPIP_H
-#       include <ws2tcpip.h>
+#      include <ws2tcpip.h>
 #    endif
 #  else
 #    ifdef HAVE_WINSOCK_H
@@ -609,6 +609,11 @@ int netware_init(void);
     defined(USE_CYASSL) || defined(USE_SCHANNEL) || \
     defined(USE_DARWINSSL) || defined(USE_GSKIT)
 #define USE_SSL    /* SSL support has been enabled */
+#endif
+
+#if !defined(CURL_DISABLE_VERBOSE_STRINGS) && \
+    defined(USE_WINDOWS_SSPI)
+#include <wincrypt.h>  /* for CRYPT_E_REVOKED macro */
 #endif
 
 /* Single point where USE_SPNEGO definition might be defined */


### PR DESCRIPTION
Starting with curl 7.44.0 [1], compiling source file `lib/strerror.c`
with mingw and SSPI enabled, may fail with error:

```
strerror.c: In function 'Curl_sspi_strerror':
strerror.c:827:10: error: 'CRYPT_E_REVOKED' undeclared (first use in this function)
     case CRYPT_E_REVOKED:
          ^
```

This happens when using mingw distros that ship with Windows headers
via the `w32api` package. Such distro is the canonical one, which is
also offered by certain [2] CI platforms. `w32api` developers implemented
[3] this macro strictly per MSDN [4], solely adding it to `wincrypt.h`,
This made it incompatible with original Windows SDK headers which define
it in `winerror.h`. Other mingw distros (f.e. [5]) that use the WINE
headers, work fine.

One solution is to comply with MSDN by #include-ing `<wincrypt.h>`
via `lib/curl_setup.h`.

This patch also fixes a TAB indentation.

[1] https://github.com/bagder/curl/commit/de74e856e63b0c6fd1e36d96d6310672abf12c29
[2] http://www.appveyor.com/docs/installed-software#mingw-msys-cygwin
[3] https://sourceforge.net/u/cstrauss/w32api/ci/3dd1f4b7cb6ab8da80e4c2bbcdb629c8c43b0d6b/
[4] https://msdn.microsoft.com/en-us/library/windows/desktop/aa377167.aspx
[5] https://sourceforge.net/projects/mingw-w64