### PR TITLE
winbuild: run buildconf.bat if necessary

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -182,6 +182,9 @@ CURL_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-curl
 DIRDIST = ..\builds\$(CONFIG_NAME_LIB)\
 
 $(MODE):
+	@IF NOT EXIST ..\include\curl\curlbuild.h ( \
+	   CALL ..\buildconf.bat \
+	)
 	@SET DIROBJ=$(LIBCURL_DIROBJ)
 	@SET MACRO_NAME=LIBCURL_OBJS
 	@SET OUTFILE=LIBCURL_OBJS.inc


### PR DESCRIPTION
Run buildconf.bat from Makefile.vc when needed. Also see issue #418 