### PR TITLE
CURLINFO_{SIZE,SPEED}_{DOWNLOAD,UPLOAD}.3: fix argument type

### DIFF
--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
@@ -26,7 +26,7 @@ CURLINFO_SIZE_DOWNLOAD \- get the number of downloaded bytes
 .SH SYNOPSIS
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_DOWNLOAD, long *dlp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_DOWNLOAD, double *dlp);
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total amount of bytes that were
 downloaded.  The amount is only for the latest transfer and will be reset

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
@@ -26,7 +26,7 @@ CURLINFO_SIZE_UPLOAD \- get the number of uploaded bytes
 .SH SYNOPSIS
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD, long *uploadp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD, double *uploadp);
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total amount of bytes that were
 uploaded.

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
@@ -26,7 +26,7 @@ CURLINFO_SPEED_DOWNLOAD \- get download speed
 .SH SYNOPSIS
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD, long *speed);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD, double *speed);
 .SH DESCRIPTION
 Pass a pointer to a double to receive the average download speed that curl
 measured for the complete download. Measured in bytes/second.

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
@@ -26,7 +26,7 @@ CURLINFO_SPEED_UPLOAD \- get upload speed
 .SH SYNOPSIS
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_UPLOAD, long *speed);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_UPLOAD, double *speed);
 .SH DESCRIPTION
 Pass a pointer to a double to receive the average upload speed that curl
 measured for the complete upload. Measured in bytes/second.


### PR DESCRIPTION
see: [lib/getinfo.c](https://github.com/bagder/curl/blob/62f306ff34f569020ce54451da7c841d162710ac/lib/getinfo.c#L231-L242)