### PR TITLE
CURLOPT_FNMATCH_FUNCTION.3: fix typo

### DIFF
--- a/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.3
@@ -37,7 +37,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FNMATCH_FUNCTION,
 Pass a pointer to your callback function, which should match the prototype
 shown above.
 
-This callback s used for wildcard matching.
+This callback is used for wildcard matching.
 
 Return \fICURL_FNMATCHFUNC_MATCH\fP if pattern matches the string,
 \fICURL_FNMATCHFUNC_NOMATCH\fP if not or \fICURL_FNMATCHFUNC_FAIL\fP if an


### PR DESCRIPTION
s => is