### PR TITLE
Initial changes to provide mbedtls 2.x support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1921,6 +1921,17 @@ dnl Initial insertion point KDD
          USE_POLARSSL="yes"
          curl_ssl_msg="enabled (PolarSSL)"
         ])
+
+      AC_CHECK_LIB(mbedtls, mbedtls_havege_init,
+      dnl libpolarssl found, set the variable
+       [
+         AC_DEFINE(USE_POLARSSL, 1, [if PolarSSL is enabled])
+         AC_SUBST(USE_POLARSSL, [1])
+         POLARSSL_ENABLED=1
+         USE_POLARSSL="yes"
+         curl_ssl_msg="enabled (PolarSSL)"
+        ])
+
     fi
 
     addld=""
@@ -1949,14 +1960,35 @@ dnl Initial insertion point KDD
        ],
        [
          CPPFLAGS=$_cppflags
-         LDFLAGS=$_ldflags
+         LDFLAGS="$_ldflags"
+         LIBS=" -lmbedtls -lmbedx509 -lmbedcrypto $LIBS"
        ])
+
+      AC_CHECK_LIB(mbedtls, mbedtls_ssl_init, 
+       [
+       AC_DEFINE(USE_POLARSSL, 1, [if PolarSSL is enabled])
+       AC_SUBST(USE_POLARSSL, [1])
+       POLARSSL_ENABLED=1
+       USE_POLARSSL="yes"
+       USE_MBEDTLS="yes"
+       curl_ssl_msg="enabled (PolarSSL)"
+       ],
+       [
+         CPPFLAGS=$_cppflags
+         LDFLAGS=$_ldflags
+       ]
+       )
+
     fi
 
     if test "x$USE_POLARSSL" = "xyes"; then
       AC_MSG_NOTICE([detected PolarSSL])
 
-      LIBS="-lpolarssl $LIBS"
+      if test "x$USE_MBEDTLS" = "xyes"; then
+        LIBS=" $LIBS"
+      else
+        LIBS="-lpolarssl $LIBS"
+      fi
 
       if test -n "$polarssllib"; then
         dnl when shared libs were found in a path that the run-time

--- a/configure.ac
+++ b/configure.ac
@@ -1975,7 +1975,6 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
        [
          CPPFLAGS=$_cppflags
          LDFLAGS=$_ldflags
-         LIBS=$INITIAL_LIBS
        ]
        )
 

--- a/configure.ac
+++ b/configure.ac
@@ -1910,8 +1910,6 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
     if test -z "$OPT_POLARSSL" ; then
       dnl check for lib first without setting any new path
 
-dnl Initial insertion point KDD
-
       AC_CHECK_LIB(polarssl, havege_init,
       dnl libpolarssl found, set the variable
        [
@@ -1976,6 +1974,7 @@ dnl Initial insertion point KDD
        [
          CPPFLAGS=$_cppflags
          LDFLAGS=$_ldflags
+         LIBS=$INITIAL_LIBS
        ]
        )
 

--- a/configure.ac
+++ b/configure.ac
@@ -1969,6 +1969,7 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
        POLARSSL_ENABLED=1
        USE_POLARSSL="yes"
        USE_MBEDTLS="yes"
+       AC_DEFINE(USE_MBEDTLS, 1, [if PolarSSL is enabled])
        curl_ssl_msg="enabled (PolarSSL)"
        ],
        [

--- a/configure.ac
+++ b/configure.ac
@@ -1910,6 +1910,8 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
     if test -z "$OPT_POLARSSL" ; then
       dnl check for lib first without setting any new path
 
+dnl Initial insertion point KDD
+
       AC_CHECK_LIB(polarssl, havege_init,
       dnl libpolarssl found, set the variable
        [

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -94,15 +94,26 @@
 #endif
 
 #ifdef USE_POLARSSL
-#include <mbedtls/compat-1.3.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/version.h>
-#if POLARSSL_VERSION_NUMBER<0x01010000
-#include <mbedtls/havege.h>
+
+/* Determine mbedtls 1.x vs. 2.x */
+#if defined(USE_MBEDTLS)
+#  include <mbedtls/compat-1.3.h>
+#  include <mbedtls/ssl.h>
+#  include <mbedtls/version.h>
+#  include <mbedtls/havege.h>
+#  include <mbedtls/entropy.h>
+#  include <mbedtls/ctr_drbg.h>
 #else
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-#endif /* POLARSSL_VERSION_NUMBER<0x01010000 */
+#  include <polarssl/ssl.h>
+#  include <polarssl/version.h>
+#  if POLARSSL_VERSION_NUMBER<0x01010000
+#    include <polarssl/havege.h>
+#  else
+#    include <polarssl/entropy.h>
+#    include <polarssl/ctr_drbg.h>
+#  endif /* POLARSSL_VERSION_NUMBER<0x01010000 */
+#endif
+
 #endif /* USE_POLARSSL */
 
 #ifdef USE_CYASSL

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -94,13 +94,14 @@
 #endif
 
 #ifdef USE_POLARSSL
-#include <polarssl/ssl.h>
-#include <polarssl/version.h>
+#include <mbedtls/compat-1.3.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/version.h>
 #if POLARSSL_VERSION_NUMBER<0x01010000
-#include <polarssl/havege.h>
+#include <mbedtls/havege.h>
 #else
-#include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
 #endif /* POLARSSL_VERSION_NUMBER<0x01010000 */
 #endif /* USE_POLARSSL */
 

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -31,20 +31,32 @@
 
 #ifdef USE_POLARSSL
 
-#include <mbedtls/compat-1.3.h>
-#include <mbedtls/net.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/certs.h>
-#include <mbedtls/x509.h>
-#include <mbedtls/version.h>
+/* Determine mbedtls 1.x vs. 2.x */
+#if defined(USE_MBEDTLS)
+#  include <mbedtls/compat-1.3.h>
+#  include <mbedtls/net.h>
+#  include <mbedtls/ssl.h>
+#  include <mbedtls/certs.h>
+#  include <mbedtls/x509.h>
+#  include <mbedtls/version.h>
+#  include <mbedtls/error.h>
+#  include <mbedtls/entropy.h>
+#  include <mbedtls/ctr_drbg.h>
+#else
+#  include <polarssl/net.h>
+#  include <polarssl/ssl.h>
+#  include <polarssl/certs.h>
+#  include <polarssl/x509.h>
+#  include <polarssl/version.h>
+#  include <polarssl/error.h>
+#  include <polarssl/entropy.h>
+#  include <polarssl/ctr_drbg.h>
+#endif
 
 #if POLARSSL_VERSION_NUMBER < 0x01030000
 #error too old PolarSSL
 #endif
 
-#include <mbedtls/error.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
 
 #include "urldata.h"
 #include "sendf.h"

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -318,18 +318,10 @@ polarssl_connect_step1(struct connectdata *conn,
   infof(data, "PolarSSL: Connecting to %s:%d\n",
         conn->host.name, conn->remote_port);
 
-#if defined(USE_MBEDTLS)
-  static mbedtls_ssl_config client_config;
-  mbedtls_ssl_config_init(&client_config);
-  ssl_init(&connssl->ssl);
-  mbedtls_ssl_setup(&connssl->ssl, &client_config);
-
-#else // Normal 1.x Call
   if(ssl_init(&connssl->ssl)) {
     failf(data, "PolarSSL: ssl_init failed");
     return CURLE_SSL_CONNECT_ERROR;
   }
-#endif // END USE_MBEDTLS
 
   switch(data->set.ssl.version) {
   default:

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -31,19 +31,20 @@
 
 #ifdef USE_POLARSSL
 
-#include <polarssl/net.h>
-#include <polarssl/ssl.h>
-#include <polarssl/certs.h>
-#include <polarssl/x509.h>
-#include <polarssl/version.h>
+#include <mbedtls/compat-1.3.h>
+#include <mbedtls/net.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/certs.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/version.h>
 
 #if POLARSSL_VERSION_NUMBER < 0x01030000
 #error too old PolarSSL
 #endif
 
-#include <polarssl/error.h>
-#include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
+#include <mbedtls/error.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
 
 #include "urldata.h"
 #include "sendf.h"

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -51,10 +51,16 @@
 #  define SHA256_CTX void *
    static NSSInitContext *nss_context;
 #elif defined(USE_POLARSSL)
-#  include <mbedtls/compat-1.3.h>
-#  include <mbedtls/md5.h>
-#  include <mbedtls/sha1.h>
-#  include <mbedtls/sha256.h>
+#  if defined(USE_MBEDTLS)
+#    include <mbedtls/compat-1.3.h>
+#    include <mbedtls/md5.h>
+#    include <mbedtls/sha1.h>
+#    include <mbedtls/sha256.h>
+#  else
+#    include <polarssl/md5.h>
+#    include <polarssl/sha1.h>
+#    include <polarssl/sha256.h>
+#  endif
 #  define MD5_CTX    md5_context
 #  define SHA_CTX    sha1_context
 #  define SHA256_CTX sha256_context

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -51,9 +51,10 @@
 #  define SHA256_CTX void *
    static NSSInitContext *nss_context;
 #elif defined(USE_POLARSSL)
-#  include <polarssl/md5.h>
-#  include <polarssl/sha1.h>
-#  include <polarssl/sha256.h>
+#  include <mbedtls/compat-1.3.h>
+#  include <mbedtls/md5.h>
+#  include <mbedtls/sha1.h>
+#  include <mbedtls/sha256.h>
 #  define MD5_CTX    md5_context
 #  define SHA_CTX    sha1_context
 #  define SHA256_CTX sha256_context


### PR DESCRIPTION
I have taken this as far as I can go.  Autoconf, configure, and make work correctly against both versions of mbedtls.  There is a conditional structure to handle the header file renames and the compatibility layer included in 2.x.  I made a single change in the polarssl.c code to accommodate an API change but ran aground just after the SSL initialization.  I don't know libcurl well enough to proceed but, hopefully, these changes can assist whomever has better libcurl kung fu than me.

Cheers

-Kurt