### PR TITLE
formdata: Add support for large multipart uploads. draft1

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -154,6 +154,7 @@ struct curl_httppost {
                                        is a file part) */
   void *userp;                      /* custom pointer used for
                                        HTTPPOST_CALLBACK posts */
+  curl_off_t contentslength_large;  /* alternative length of contents field */
 };
 
 /* This is the CURLOPT_PROGRESSFUNCTION callback proto. It is now considered
@@ -1822,6 +1823,8 @@ typedef enum {
   CFINIT(OBSOLETE2),
 
   CFINIT(STREAM),
+
+  CFINIT(CONTENTSLENGTH_LARGE),
 
   CURLFORM_LASTENTRY /* the last unused */
 } CURLformoption;

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -36,7 +36,7 @@ struct FormData {
   struct FormData *next;
   enum formtype type;
   char *line;
-  size_t length;
+  curl_off_t length;
 };
 
 struct Form {
@@ -54,7 +54,7 @@ typedef struct FormInfo {
   size_t namelength;
   char *value;
   bool value_alloc;
-  size_t contentslength;
+  curl_off_t contentslength;
   char *contenttype;
   bool contenttype_alloc;
   long flags;


### PR DESCRIPTION
- Change internal use of contentslength to curl_off_t.

- Expose as contentslength_large in curl_httppost.

Bug: https://github.com/bagder/curl/issues/425
Reported-by: thready@users.noreply.github.com