### PR TITLE
A proxy host string given in an environment gets no special treatment

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -61,8 +61,8 @@ option does however override any possibly set environment variables.
 Setting the proxy string to "" (an empty string) will explicitly disable the
 use of a proxy, even if there is an environment variable set for it.
 
-A proxy host string given in an environment variable can also include protocol
-scheme (http://) and embedded user + password.
+A proxy host string can also include protocol scheme (http://) and embedded
+user + password.
 .SH DEFAULT
 Default is NULL, meaning no proxy is used.
 


### PR DESCRIPTION
The current wording suggests a proxy host string given in an environment variable is treated differently than setting CURLOPT_PROXY via curl_easy_setopt() for example. However, according to lib/url.c there is no difference.
