### PR TITLE
tool: Generate easysrc with last cache linked-list

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -23,6 +23,7 @@ CURLX_HFILES = \
 	../lib/warnless.h
 
 CURL_CFILES = \
+	slist_wc.c \
 	tool_binmode.c \
 	tool_bname.c \
 	tool_cb_dbg.c \
@@ -64,6 +65,7 @@ CURL_CFILES = \
 	tool_xattr.c
 
 CURL_HFILES = \
+	slist_wc.h \
 	tool_binmode.h \
 	tool_bname.h \
 	tool_cb_dbg.h \

--- a/src/Makefile.vc6
+++ b/src/Makefile.vc6
@@ -145,6 +145,7 @@ RELEASE_OBJS= \
 	rawstrr.obj \
 	strtoofftr.obj \
 	warnless.obj \
+	slist_wc.obj \
 	tool_binmoder.obj \
 	tool_bnamer.obj \
 	tool_cb_dbgr.obj \
@@ -190,6 +191,7 @@ DEBUG_OBJS= \
 	rawstrd.obj \
 	strtoofftd.obj \
 	warnlessd.obj \
+	slist_wc.obj \
 	tool_binmoded.obj \
 	tool_bnamed.obj \
 	tool_cb_dbgd.obj \
@@ -367,6 +369,8 @@ strtoofftr.obj: ../lib/strtoofft.c
 	$(CCR) $(CFLAGS) /Fo"$@" ../lib/strtoofft.c
 warnless.obj: ../lib/warnless.c
 	$(CCR) $(CFLAGS) /Fo"$@" ../lib/warnless.c
+slist_wc.obj: slist_wc.c
+	$(CCR) $(CFLAGS) /Fo"$@" slist_wc.c
 tool_binmoder.obj: tool_binmode.c
 	$(CCR) $(CFLAGS) /Fo"$@" tool_binmode.c
 tool_bnamer.obj: tool_bname.c
@@ -455,6 +459,8 @@ strtoofftd.obj: ../lib/strtoofft.c
 	$(CCD) $(CFLAGS) /Fo"$@" ../lib/strtoofft.c
 warnlessd.obj: ../lib/warnless.c
 	$(CCD) $(CFLAGS) /Fo"$@" ../lib/warnless.c
+slist_wc.obj: slist_wc.c
+	$(CCD) $(CFLAGS) /Fo"$@" slist_wc.c
 tool_binmoded.obj: tool_binmode.c
 	$(CCD) $(CFLAGS) /Fo"$@" tool_binmode.c
 tool_bnamed.obj: tool_bname.c

--- a/src/slist_wc.c
+++ b/src/slist_wc.c
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "tool_setup.h"
+
+#ifndef CURL_DISABLE_LIBCURL_OPTION
+
+#include "slist_wc.h"
+
+/* The last #include files should be: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
+/*
+ * curl_slist_wc_append() appends a string to the linked list. This function
+ * can be used as an initialization function as well as an append function.
+ */
+struct curl_slist_wc *curl_slist_wc_append(struct curl_slist_wc *list,
+                                           const char *data)
+{
+  struct curl_slist *new_item = curl_slist_append(NULL, data);
+
+  if(!new_item)
+    return NULL;
+
+  if(!list) {
+    list = malloc(sizeof(struct curl_slist_wc));
+
+    if(!list) {
+      free(new_item);
+      return NULL;
+    }
+
+    list->first = new_item;
+    list->last = new_item;
+    return list;
+  }
+
+  list->last->next = new_item;
+  list->last = list->last->next;
+  return list;
+}
+
+/* be nice and clean up resources */
+void curl_slist_wc_free_all(struct curl_slist_wc *list)
+{
+  if(!list)
+    return;
+
+  curl_slist_free_all(list->first);
+  free(list);
+}
+
+#endif /* CURL_DISABLE_LIBCURL_OPTION */

--- a/src/slist_wc.h
+++ b/src/slist_wc.h
@@ -1,0 +1,57 @@
+#ifndef HEADER_CURL_SLIST_WC_H
+#define HEADER_CURL_SLIST_WC_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "tool_setup.h"
+#ifndef CURL_DISABLE_LIBCURL_OPTION
+
+/* linked-list structure with last node cache for easysrc */
+struct curl_slist_wc {
+  struct curl_slist *first;
+  struct curl_slist *last;
+};
+
+/*
+ * NAME curl_slist_wc_append()
+ *
+ * DESCRIPTION
+ *
+ * Appends a string to a linked list. If no list exists, it will be created
+ * first. Returns the new list, after appending.
+ */
+struct curl_slist_wc *curl_slist_wc_append(struct curl_slist_wc *,
+                                           const char *);
+
+/*
+ * NAME curl_slist_free_all()
+ *
+ * DESCRIPTION
+ *
+ * free a previously built curl_slist_wc.
+ */
+void curl_slist_wc_free_all(struct curl_slist_wc *);
+
+#endif /* CURL_DISABLE_LIBCURL_OPTION */
+
+#endif /* HEADER_CURL_SLIST_WC_H */
+

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -21,6 +21,8 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+#include "slist_wc.h"
+
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 
 #define ENABLE_CURLX_PRINTF
@@ -35,11 +37,11 @@
 
 /* global variable definitions, for easy-interface source code generation */
 
-struct curl_slist *easysrc_decl = NULL; /* Variable declarations */
-struct curl_slist *easysrc_data = NULL; /* Build slists, forms etc. */
-struct curl_slist *easysrc_code = NULL; /* Setopt calls */
-struct curl_slist *easysrc_toohard = NULL; /* Unconvertible setopt */
-struct curl_slist *easysrc_clean = NULL;  /* Clean up allocated data */
+struct curl_slist_wc *easysrc_decl = NULL; /* Variable declarations */
+struct curl_slist_wc *easysrc_data = NULL; /* Build slists, forms etc. */
+struct curl_slist_wc *easysrc_code = NULL; /* Setopt calls */
+struct curl_slist_wc *easysrc_toohard = NULL; /* Unconvertible setopt */
+struct curl_slist_wc *easysrc_clean = NULL;  /* Clean up allocated data */
 int easysrc_form_count = 0;
 int easysrc_slist_count = 0;
 
@@ -77,24 +79,23 @@ static const char *const srcend[]={
 /* Clean up all source code if we run out of memory */
 static void easysrc_free(void)
 {
-  curl_slist_free_all(easysrc_decl);
+  curl_slist_wc_free_all(easysrc_decl);
   easysrc_decl = NULL;
-  curl_slist_free_all(easysrc_data);
+  curl_slist_wc_free_all(easysrc_data);
   easysrc_data = NULL;
-  curl_slist_free_all(easysrc_code);
+  curl_slist_wc_free_all(easysrc_code);
   easysrc_code = NULL;
-  curl_slist_free_all(easysrc_toohard);
+  curl_slist_wc_free_all(easysrc_toohard);
   easysrc_toohard = NULL;
-  curl_slist_free_all(easysrc_clean);
+  curl_slist_wc_free_all(easysrc_clean);
   easysrc_clean = NULL;
 }
 
 /* Add a source line to the main code or remarks */
-CURLcode easysrc_add(struct curl_slist **plist, const char *line)
+CURLcode easysrc_add(struct curl_slist_wc **plist, const char *line)
 {
   CURLcode ret = CURLE_OK;
-  struct curl_slist *list =
-    curl_slist_append(*plist, line);
+  struct curl_slist_wc *list = curl_slist_wc_append(*plist, line);
   if(!list) {
     easysrc_free();
     ret = CURLE_OUT_OF_MEMORY;
@@ -104,7 +105,7 @@ CURLcode easysrc_add(struct curl_slist **plist, const char *line)
   return ret;
 }
 
-CURLcode easysrc_addf(struct curl_slist **plist, const char *fmt, ...)
+CURLcode easysrc_addf(struct curl_slist_wc **plist, const char *fmt, ...)
 {
   CURLcode ret;
   char *bufp;
@@ -143,12 +144,14 @@ CURLcode easysrc_perform(void)
     for(i=0; ((c = srchard[i]) != NULL); i++)
       CHKRET(easysrc_add(&easysrc_code, c));
     /* Each unconverted option */
-    for(ptr=easysrc_toohard; ptr; ptr = ptr->next)
-      CHKRET(easysrc_add(&easysrc_code, ptr->data));
+    if(easysrc_toohard) {
+      for(ptr=easysrc_toohard->first; ptr; ptr = ptr->next)
+        CHKRET(easysrc_add(&easysrc_code, ptr->data));
+    }
     CHKRET(easysrc_add(&easysrc_code, ""));
     CHKRET(easysrc_add(&easysrc_code, "*/"));
 
-    curl_slist_free_all(easysrc_toohard);
+    curl_slist_wc_free_all(easysrc_toohard);
     easysrc_toohard = NULL;
   }
 
@@ -190,29 +193,35 @@ void dumpeasysrc(struct GlobalConfig *config)
       fprintf(out, "%s\n", c);
 
     /* Declare variables used for complex setopt values */
-    for(ptr=easysrc_decl; ptr; ptr = ptr->next)
-      fprintf(out, "  %s\n", ptr->data);
+    if(easysrc_decl) {
+      for(ptr=easysrc_decl->first; ptr; ptr = ptr->next)
+        fprintf(out, "  %s\n", ptr->data);
+    }
 
     /* Set up complex values for setopt calls */
     if(easysrc_data) {
       fprintf(out, "\n");
 
-      for(ptr=easysrc_data; ptr; ptr = ptr->next)
+      for(ptr=easysrc_data->first; ptr; ptr = ptr->next)
         fprintf(out, "  %s\n", ptr->data);
     }
 
     fprintf(out, "\n");
-    for(ptr=easysrc_code; ptr; ptr = ptr->next) {
-      if(ptr->data[0]) {
-        fprintf(out, "  %s\n", ptr->data);
-      }
-      else {
-        fprintf(out, "\n");
+    if(easysrc_code) {
+      for(ptr=easysrc_code->first; ptr; ptr = ptr->next) {
+        if(ptr->data[0]) {
+          fprintf(out, "  %s\n", ptr->data);
+        }
+        else {
+          fprintf(out, "\n");
+        }
       }
     }
 
-    for(ptr=easysrc_clean; ptr; ptr = ptr->next)
-      fprintf(out, "  %s\n", ptr->data);
+    if(easysrc_clean) {
+      for(ptr=easysrc_clean->first; ptr; ptr = ptr->next)
+        fprintf(out, "  %s\n", ptr->data);
+    }
 
     for(i=0; ((c = srcend[i]) != NULL); i++)
       fprintf(out, "%s\n", c);

--- a/src/tool_easysrc.h
+++ b/src/tool_easysrc.h
@@ -26,18 +26,19 @@
 
 /* global variable declarations, for easy-interface source code generation */
 
-extern struct curl_slist *easysrc_decl; /* Variable declarations */
-extern struct curl_slist *easysrc_data; /* Build slists, forms etc. */
-extern struct curl_slist *easysrc_code; /* Setopt calls etc. */
-extern struct curl_slist *easysrc_toohard; /* Unconvertible setopt */
-extern struct curl_slist *easysrc_clean;  /* Clean up (reverse order) */
+extern struct curl_slist_wc *easysrc_decl; /* Variable declarations */
+extern struct curl_slist_wc *easysrc_data; /* Build slists, forms etc. */
+extern struct curl_slist_wc *easysrc_code; /* Setopt calls etc. */
+extern struct curl_slist_wc *easysrc_toohard; /* Unconvertible setopt */
+extern struct curl_slist_wc *easysrc_clean;  /* Clean up (reverse order) */
 
 extern int easysrc_form_count;  /* Number of curl_httppost variables */
 extern int easysrc_slist_count; /* Number of curl_slist variables */
 
 extern CURLcode easysrc_init(void);
-extern CURLcode easysrc_add(struct curl_slist **plist, const char *bupf);
-extern CURLcode easysrc_addf(struct curl_slist **plist, const char *fmt, ...);
+extern CURLcode easysrc_add(struct curl_slist_wc **plist, const char *bupf);
+extern CURLcode easysrc_addf(struct curl_slist_wc **plist,
+                             const char *fmt, ...);
 extern CURLcode easysrc_perform(void);
 extern CURLcode easysrc_cleanup(void);
 


### PR DESCRIPTION
Using a last cache linked-list improves the performance of easysrc generation.

Bug: https://github.com/bagder/curl/issues/444
Ref: https://github.com/bagder/curl/issues/429