### PR TITLE
fix gopher don't send NUL byte bug

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -83,16 +83,17 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   char *sel;
   char *sel_org = NULL;
   ssize_t amount, k;
+  int len;
 
   *done = TRUE; /* unconditionally */
 
   /* Create selector. Degenerate cases: / and /1 => convert to "" */
   if(strlen(path) <= 2)
     sel = (char *)"";
+    len = strlen(sel);
   else {
     char *newp;
     size_t j, i;
-    int len;
 
     /* Otherwise, drop / and the first character (i.e., item type) ... */
     newp = path;
@@ -113,7 +114,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
 
   /* We use Curl_write instead of Curl_sendf to make sure the entire buffer is
      sent, which could be sizeable with long selectors. */
-  k = curlx_uztosz(strlen(sel));
+  k = curlx_uztosz(len);
 
   for(;;) {
     result = Curl_write(conn, sockfd, sel, k, &amount);


### PR DESCRIPTION
I find that gopher scheme (gopher://) do not support NUL byte.
I read the source code and find that gopher.c use STRLEN(SEL) to process the URL-DECODED data.
But "curl_easy_unescape" already has specified OUTLENGTH. so I change the STRLEN(SEL) to OUTLENGTH.