### PR TITLE
--libcurl: problem with output of non-printable characters was fixed

### DIFF
--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -227,7 +227,7 @@ static char *c_escape(const char *str)
       e += 2;
     }
     else if(! isprint(c)) {
-      snprintf(e, 4, "\\%03o", c);
+      snprintf(e, 5, "\\%03o", c);
       e += 4;
     }
     else


### PR DESCRIPTION
Hello.
I have found a little problem with output of non-printable characters when --libcurl option is used.
For example, we are trying to post contents of **binfile.bin** file with non-printable characters inside:

~> cat binfile.bin


~> curl --libcurl ~/result.c --request POST --data-binary "@binfile.bin" http://tut.by
*some cURL output*

~> cat result.c
*// skip a few lines*
*curl_easy_setopt(hnd, CURLOPT_POSTFIELDS,* **"\02"***);*

As you can see, the content of **binfile.bin** file was not copied correctly to the generated C source file.
The problem occurs because *snprintf* function reserves space for the additional terminating null character. The fix is provided in 9414a9ef364d90426704641d321c0639e6107952 commit.