### PR TITLE
Passing the pointer of the pointer of the ConnInfo

### DIFF
--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -330,7 +330,7 @@ static void new_conn(char *url, GlobalInfo *g )
   conn->url = strdup(url);
   curl_easy_setopt(conn->easy, CURLOPT_URL, conn->url);
   curl_easy_setopt(conn->easy, CURLOPT_WRITEFUNCTION, write_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEDATA, &conn);
+  curl_easy_setopt(conn->easy, CURLOPT_WRITEDATA, conn);
   curl_easy_setopt(conn->easy, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(conn->easy, CURLOPT_ERRORBUFFER, conn->error);
   curl_easy_setopt(conn->easy, CURLOPT_PRIVATE, conn);


### PR DESCRIPTION
I was playing with the code and I found a bug with the way the ConnInfo was being passed to the write callback.
