### PR TITLE
Fix condition for Curl_des_set_odd_parity

### DIFF
--- a/lib/curl_des.h
+++ b/lib/curl_des.h
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && (!defined(USE_OPENSSL) || defined(HAVE_BORINGSSL))
+#if defined(USE_NTLM) && !defined(HAVE_DES_SET_ODD_PARITY)
 
 /* Applies odd parity to the given byte array */
 void Curl_des_set_odd_parity(unsigned char *bytes, size_t length);


### PR DESCRIPTION
This ifdef seems to be wrong. The places where this function is called (and defined) use this:

!defined(HAVE_DES_SET_ODD_PARITY)