### PR TITLE
http2: Fix http2_recv to return -1 if recv returned -1

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1094,15 +1094,11 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
       nread = ((Curl_recv *)httpc->recv_underlying)(
           conn, FIRSTSOCKET, httpc->inbuf, H2_BUFSIZE, &result);
 
-      if(result == CURLE_AGAIN) {
+      if(nread == -1) {
+        if(result != CURLE_AGAIN)
+          failf(data, "Failed receiving HTTP2 data");
         *err = result;
         return -1;
-      }
-
-      if(nread == -1) {
-        failf(data, "Failed receiving HTTP2 data");
-        *err = result;
-        return 0;
       }
 
       if(nread == 0) {


### PR DESCRIPTION
If the underlying recv called by http2_recv returns -1 then that is the
value http2_recv returns to the caller.

---

@bagder prior to this it returned 0 in that case, which looks like an oversight to me but I'm not sure if maybe I'm missing something important here.