### PR TITLE
http: Don't wait for a body in the response for HEAD requests.

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3396,28 +3396,19 @@ CURLcode Curl_http_readwrite_headers(struct SessionHandle *data,
           }
         }
 
-        switch(k->httpcode) {
-        case 204:
-          /* (quote from RFC2616, section 10.2.5): The server has
-           * fulfilled the request but does not need to return an
-           * entity-body ... The 204 response MUST NOT include a
-           * message-body, and thus is always terminated by the first
-           * empty line after the header fields. */
-          /* FALLTHROUGH */
-        case 304:
-          /* (quote from RFC2616, section 10.3.5): The 304 response
-           * MUST NOT contain a message-body, and thus is always
-           * terminated by the first empty line after the header
-           * fields.  */
+        if(data->set.httpreq == HTTPREQ_HEAD ||
+            k->httpcode == 204 || k->httpcode == 304) {
+          /* (quote from RFC2616, section 4.4.1): Any response message
+           * which "MUST NOT" include a message-body (such as the 1xx,
+           * 204, and 304 responses and any response to a HEAD request)
+           * is always terminated by the first empty line after the header
+           * fields, regardless of the entity-header fields present
+           * in the message. */
           if(data->set.timecondition)
             data->info.timecond = TRUE;
           k->size=0;
           k->maxdownload=0;
           k->ignorecl = TRUE; /* ignore Content-Length headers */
-          break;
-        default:
-          /* nothing */
-          break;
         }
       }
       else {


### PR DESCRIPTION
[Section 4.4 of RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4):
> 1. Any response message which "MUST NOT" include
a message-body (such as the 1xx, 204, and 304 responses and any response
to a HEAD request) is always terminated by the first empty line after
the header fields, regardless of the entity-header fields present in the
message.

and [Section 14.13 of RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13):

> The Content-Length entity-header field
indicates the size of the entity-body, in decimal number of OCTETs, sent
to the recipient or, in the case of the HEAD method, the size of the
entity-body that would have been sent had the request been a GET.

But curl stucks in waiting for a body if response contains `Content-Length` header:

```console
curl -v -XHEAD 'http://exmaple.com'
* Rebuilt URL to: http://exmaple.com/
*   Trying 85.119.83.248...
* Connected to exmaple.com (85.119.83.248) port 80 (#0)
> HEAD / HTTP/1.1
> Host: exmaple.com
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sun, 11 Oct 2015 16:23:18 GMT
< Server: Apache
< Last-Modified: Tue, 20 Dec 2005 14:48:11 GMT
< ETag: "c0cc-4a8-4085bc1a980c0"
< Accept-Ranges: bytes
< Content-Length: 1192
< Vary: Accept-Encoding
< Content-Type: text/html
<
^C
```