### PR TITLE
Don't check for continuation if we're executing a CUSTOMREQUEST

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -360,8 +360,8 @@ static bool imap_endofresp(struct connectdata *conn, char *line, size_t len,
      a space and optionally some text as per RFC-3501 for the AUTHENTICATE and
      APPEND commands and as outlined in Section 4. Examples of RFC-4959 but
      some e-mail servers ignore this and only send a single + instead. */
-  if((len == 3 && !memcmp("+", line, 1)) ||
-     (len >= 2 && !memcmp("+ ", line, 2))) {
+  if(!imap->custom && ((len == 3 && !memcmp("+", line, 1)) ||
+     (len >= 2 && !memcmp("+ ", line, 2)))) {
     switch(imapc->state) {
       /* States which are interested in continuation responses */
       case IMAP_AUTHENTICATE:

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -86,7 +86,7 @@ test800 test801 test802 test803 test804 test805 test806 test807 test808 \
 test809 test810 test811 test812 test813 test814 test815 test816 test817 \
 test818 test819 test820 test821 test822 test823 test824 test825 test826 \
 test827 test828 test829 test830 test831 test832 test833 test834 test835 \
-test836 test837 test838 test839 test840 \
+test836 test837 test838 test839 test840 test841 \
 \
 test850 test851 test852 test853 test854 test855 test856 test857 test858 \
 test859 test860 test861 test862 test863 test864 test865 test866 test867 \

--- a/tests/data/test841
+++ b/tests/data/test841
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+FETCH
+CUSTOMREQUEST
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+body
+
++ Curl did not used to like this line
+--
+  yours sincerely
+</data>
+<datacheck>
+* 123 FETCH (BODY[1] {70}
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP custom request doesn't check continuation data
+ </name>
+ <command>
+ imap://%HOSTIP:%IMAPPORT/841/ -u user:secret -X 'FETCH 123 BODY[1]'
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+A002 LOGIN user secret
+A003 SELECT 841
+A004 FETCH 123 BODY[1]
+A005 LOGOUT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Closes bagder/curl#486