### PR TITLE
CURLOPT_CABUNDLE and CURLOPT_CABUNDLESIZE with PolarSSL support

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1648,6 +1648,12 @@ typedef enum {
   /* Set the protocol used when curl is given a URL without a protocol */
   CINIT(DEFAULT_PROTOCOL, OBJECTPOINT, 238),
 
+  /* This points to a SSL CA Bundle data */
+  CINIT(CABUNDLE, OBJECTPOINT, 239),
+ 
+  /* size of the SSL CA Bundle data, if strlen() is not good to use */
+  CINIT(CABUNDLESIZE, LONG, 240),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -2092,6 +2092,18 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
     result = setstropt(&data->set.str[STRING_SSL_CAFILE],
                        va_arg(param, char *));
     break;
+  case CURLOPT_CABUNDLE:
+    /*
+     * Set CA bundle for SSL connection. Specify pointer to the CA certificate bundle
+     */
+    data->set.ssl_cabundle_data = va_arg(param, void *);
+    break;
+  case CURLOPT_CABUNDLESIZE:
+    /*
+     * Set CA bundle size for SSL connection if strlen() is not suitable.
+     */
+    data->set.ssl_cabundle_size = va_arg(param, long);
+    break;
   case CURLOPT_CAPATH:
 #ifdef have_curlssl_ca_path /* not supported by all backends */
     /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1631,6 +1631,8 @@ struct UserDefined {
   bool pipewait;        /* wait for pipe/multiplex status before starting a
                            new connection */
   long expect_100_timeout; /* in milliseconds */
+  void* ssl_cabundle_data; /* SSL CA bundle data pointer */
+  curl_off_t ssl_cabundle_size; /* SSL CA bundle size in bytes */
 };
 
 struct Names {


### PR DESCRIPTION
An option to set in-memory SSL CA bundle.
Implementation for the PolarSSL backend.