### PR TITLE
NSS, PolarSSL, CyaSSL, axTLS backend updates for HTTPS proxy

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -4767,6 +4767,7 @@ static CURLcode parse_proxy(struct SessionHandle *data,
   long port = -1;
   char *proxyuser = NULL;
   char *proxypasswd = NULL;
+  bool sockstype;
 
   /* We do the proxy host string parsing here. We want the host name and the
    * port name. Accept a protocol:// prefix
@@ -4791,10 +4792,10 @@ static CURLcode parse_proxy(struct SessionHandle *data,
   else
     proxyptr = proxy; /* No xxx:// head: It's a HTTP proxy */
 
-  bool sockstype = proxytype == CURLPROXY_SOCKS5_HOSTNAME ||
-                   proxytype == CURLPROXY_SOCKS5 ||
-                   proxytype == CURLPROXY_SOCKS4A ||
-                   proxytype == CURLPROXY_SOCKS4;
+  sockstype = proxytype == CURLPROXY_SOCKS5_HOSTNAME ||
+              proxytype == CURLPROXY_SOCKS5 ||
+              proxytype == CURLPROXY_SOCKS4A ||
+              proxytype == CURLPROXY_SOCKS4;
 
   /* Is there a username and password given in this proxy url? */
   atsign = strchr(proxyptr, '@');

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -34,6 +34,8 @@ CURLcode Curl_gtls_connect(struct connectdata *conn, int sockindex);
 CURLcode Curl_gtls_connect_nonblocking(struct connectdata *conn,
                                        int sockindex,
                                        bool *done);
+bool Curl_gtls_data_pending(const struct connectdata *conn,
+                            int connindex);
 
  /* close a SSL connection */
 void Curl_gtls_close(struct connectdata *conn, int sockindex);
@@ -74,7 +76,7 @@ bool Curl_gtls_cert_status_request(void);
 #define curlssl_engines_list(x) ((void)x, (struct curl_slist *)NULL)
 #define curlssl_version Curl_gtls_version
 #define curlssl_check_cxn(x) ((void)x, -1)
-#define curlssl_data_pending(x,y) ((void)x, (void)y, 0)
+#define curlssl_data_pending(x,y) Curl_gtls_data_pending(x,y)
 #define curlssl_random(x,y,z) Curl_gtls_random(x,y,z)
 #define curlssl_md5sum(a,b,c,d) Curl_gtls_md5sum(a,b,c,d)
 #define curlssl_cert_status_request() Curl_gtls_cert_status_request()

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -308,7 +308,7 @@ ssl_connect_init_proxy(struct connectdata *conn, int sockindex) {
   DEBUGASSERT(conn->bits.proxy_ssl_connected[sockindex]);
   if(ssl_connection_complete == conn->ssl[sockindex].state &&
      !conn->proxy_ssl[sockindex].use) {
-#ifdef USE_OPENSSL
+#if defined(USE_OPENSSL) || defined(USE_NSS)
     conn->proxy_ssl[sockindex] = conn->ssl[sockindex];
     memset(&conn->ssl[sockindex], 0, sizeof(conn->ssl[sockindex]));
 #else

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -308,7 +308,7 @@ ssl_connect_init_proxy(struct connectdata *conn, int sockindex) {
   DEBUGASSERT(conn->bits.proxy_ssl_connected[sockindex]);
   if(ssl_connection_complete == conn->ssl[sockindex].state &&
      !conn->proxy_ssl[sockindex].use) {
-#if defined(USE_OPENSSL) || defined(USE_NSS)
+#if defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_NSS)
     conn->proxy_ssl[sockindex] = conn->ssl[sockindex];
     memset(&conn->ssl[sockindex], 0, sizeof(conn->ssl[sockindex]));
 #else

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -48,7 +48,9 @@
 /* set of helper macros for the backends to access the correct fields. For the
    proxy or for the remote host - to properly support HTTPS proxy */
 
-#define SSL_IS_PROXY() (CURLPROXY_HTTPS == conn->http_proxy.proxytype)
+#define SSL_IS_PROXY() (CURLPROXY_HTTPS == conn->http_proxy.proxytype && \
+  ssl_connection_complete != conn->proxy_ssl[conn->sock[SECONDARYSOCKET] == \
+  CURL_SOCKET_BAD ? FIRSTSOCKET : SECONDARYSOCKET].state)
 #define SSL_SET_OPTION(var) (SSL_IS_PROXY() ? data->set.proxy_ssl.var : \
                              data->set.ssl.var)
 #define SSL_CONN_CONFIG(var) (SSL_IS_PROXY() ?          \


### PR DESCRIPTION
NSS: Build fixed and HTTPS proxy appears to work with this backend in our simple tests. We could not test SFTP support though (it did not appear to work before our changes).

PolarSSL, CyaSSL, axTLS: Build fixed. However, these backends lack changes to actually support HTTPS proxying (ssl_connect_init_proxy returns CURLE_NOT_BUILT_IN).

Some "make check" test cases fail, but there are no _new_ failures after these changes (compared to failures in commit 616cecfdb6b377b7920f4b6bfe1bb775463c7f73).