### PR TITLE
Add missing feature macros in CMake config header

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -24,6 +24,12 @@
 /* to disable FTP */
 #cmakedefine CURL_DISABLE_FTP 1
 
+/* to disable GOPHER */
+#cmakedefine CURL_DISABLE_GOPHER 1
+
+/* to disable IMAP */
+#cmakedefine CURL_DISABLE_IMAP 1
+
 /* to disable HTTP */
 #cmakedefine CURL_DISABLE_HTTP 1
 
@@ -33,8 +39,14 @@
 /* to disable LDAPS */
 #cmakedefine CURL_DISABLE_LDAPS 1
 
+/* to disable POP3 */
+#cmakedefine CURL_DISABLE_POP3 1
+
 /* to disable proxies */
 #cmakedefine CURL_DISABLE_PROXY 1
+
+/* to disable SMTP */
+#cmakedefine CURL_DISABLE_SMTP 1
 
 /* to disable TELNET */
 #cmakedefine CURL_DISABLE_TELNET 1


### PR DESCRIPTION
The curl_config.h file can be generated either from curl_config.h.cmake
or curl_config.h.in, depending on whether you're building using CMake or
the autotools.  The CMake template header doesn't include entries for
all of the protocols that you can disable, which (I think) means that
you can't actually disable those protocols when building via CMake.