### PR TITLE
Work with stricter BoringSSL BIO_get_mem_data

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2517,12 +2517,12 @@ static CURLcode servercert(struct connectdata *conn,
   infof(data, "\t subject: %s\n", rc?"[NONE]":buffer);
 
   ASN1_TIME_print(mem, X509_get_notBefore(connssl->server_cert));
-  len = BIO_get_mem_data(mem, &ptr);
+  len = BIO_get_mem_data(mem, (char **) &ptr);
   infof(data, "\t start date: %.*s\n", len, ptr);
   BIO_reset(mem);
 
   ASN1_TIME_print(mem, X509_get_notAfter(connssl->server_cert));
-  len = BIO_get_mem_data(mem, &ptr);
+  len = BIO_get_mem_data(mem, (char **) &ptr);
   infof(data, "\t expire date: %.*s\n", len, ptr);
   BIO_reset(mem);
 


### PR DESCRIPTION
BoringSSL implements `BIO_get_mem_data` as a function, instead of a
macro, and expects the output pointer to be a `char **`.  We have to add
an explicit cast to grab the pointer as a `const char **`.