### PR TITLE
Don't call recv(2) if socket == -1

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1242,10 +1242,10 @@ curl_socket_t Curl_getconnectinfo(struct SessionHandle *data,
     }
 /* Minix 3.1 doesn't support any flags on recv; just assume socket is OK */
 #ifdef MSG_PEEK
-    else {
+    else if(sockfd != CURL_SOCKET_BAD) {
       /* use the socket */
       char buf;
-      if(recv((RECV_TYPE_ARG1)c->sock[FIRSTSOCKET], (RECV_TYPE_ARG2)&buf,
+      if(recv((RECV_TYPE_ARG1)sockfd, (RECV_TYPE_ARG2)&buf,
               (RECV_TYPE_ARG3)1, (RECV_TYPE_ARG4)MSG_PEEK) == 0) {
         return CURL_SOCKET_BAD;   /* FIN received */
       }


### PR DESCRIPTION
This one leads to an assert in our network layer on one of our platforms. It seems like there's no use in peeking on a socket that is known to be bad.