### PR TITLE
zsh completion: Preserve single quotes in output

### DIFF
--- a/scripts/zsh.pl
+++ b/scripts/zsh.pl
@@ -45,7 +45,7 @@ sub parse_main_opts {
 
         my $option = '';
 
-        $desc =~ s/'/''/g if defined $desc;
+        $desc =~ s/'/'\\''/g if defined $desc;
         $desc =~ s/\[/\\\[/g if defined $desc;
         $desc =~ s/\]/\\\]/g if defined $desc;
 


### PR DESCRIPTION
When an option's help string contains literal single quotes, those single quotes would be stripped from the option's description in the completion output (unless the zsh RC_QUOTES option were set while the completion function was being sourced, which is not the default).  This patch makes the completion output contain single quotes where the --help output does.

Here's a comparison of the output before and after this patch:

```diff
--- before	2015-11-18 21:56:12.434864422 +0000
+++ after	2015-11-18 21:56:07.458835620 +0000
@@ -8,11 +8,11 @@
 local rc=1
 
 _arguments -C -S \
-  {-y,--speed-time}'[Trigger ''speed-limit'' abort after SECONDS (default: 30)]':SECONDS \
+  {-y,--speed-time}'[Trigger '\''speed-limit'\'' abort after SECONDS (default: 30)]':SECONDS \
   --proxy-negotiate'[Use HTTP Negotiate (SPNEGO) authentication on the proxy (H)]' \
+  {-Y,--speed-limit}'[Stop transfers below RATE for '\''speed-time'\'' secs]':RATE \
+  --location-trusted'[Like '\''--location'\'', and send auth to other hosts (H)]' \
   {-S,--show-error}'[Show error. With -s, make curl show errors when they occur]' \
-  {-Y,--speed-limit}'[Stop transfers below RATE for ''speed-time'' secs]':RATE \
-  --location-trusted'[Like ''--location'', and send auth to other hosts (H)]' \
   {-c,--cookie-jar}'[Write cookies to FILE after operation (H)]':FILE:_files \
   --ftp-alternative-to-user'[String to replace "USER \[name\]" (F)]':COMMAND \
   --ftp-ssl-control'[Require SSL/TLS for FTP login, clear for transfer (F)]' \
@@ -22,6 +22,7 @@
   --hostpubmd5'[Hex-encoded MD5 string of the host public key. (SSH)]':MD5 \
   {-j,--junk-session-cookies}'[Ignore session cookies read from file (H)]' \
   {-E,--cert}'[Client certificate file and password (SSL)]':CERT[:PASSWD] \
+  {-R,--remote-time}'[Set the remote file'\''s time on the local output]' \
   {-P,--ftp-port}'[Use PORT with given address instead of PASV (F)]':ADR \
   {-Q,--quote}'[Send command(s) to server before transfer (F/SFTP)]':CMD \
   --socks5-hostname'[SOCKS5 proxy, pass host name to proxy]':HOST[:PORT] \
@@ -29,7 +30,6 @@
   --dns-ipv6-addr'[IPv6 address to use for DNS requests, dot notation]' \
   --engine'[Crypto engine (use "--engine list" for list) (SSL)]':ENGINE \
   {-O,--remote-name}'[Write output to a file named as the remote file]' \
-  {-R,--remote-time}'[Set the remote file''s time on the local output]' \
   --socks5-gssapi-service'[SOCKS5 proxy service name for GSS-API]':NAME \
   --stderr'[Where to redirect stderr (use "-" for stdout)]':FILE:_files \
   {-g,--globoff}'[Disable URL sequences and ranges using {} and \[\]]' \
@@ -105,6 +105,7 @@
   --proxy-ntlm'[Use NTLM authentication on the proxy (H)]' \
   {-X,--request}'[Specify request command to use]':COMMAND \
   --data-urlencode'[HTTP POST data url encoded (H)]':DATA \
+  {-s,--silent}'[Silent mode (don'\''t output anything)]' \
   --trace-time'[Add time stamps to trace/verbose output]' \
   {-u,--user}'[Server user and password]':USER[:PASSWORD] \
   --ftp-skip-pasv-ip'[Skip the IP address for PASV (F)]' \
@@ -114,7 +115,6 @@
   --mail-rcpt'[Mail to this/these addresses (SMTP)]':TO \
   --metalink'[Process given URLs as metalink XML file]' \
   --retry-delay'[Wait SECONDS between retries]':SECONDS \
-  {-s,--silent}'[Silent mode (don''t output anything)]' \
   --ssl-reqd'[Require SSL/TLS (FTP, IMAP, POP3, SMTP)]' \
   --xattr'[Store metadata in extended file attributes]' \
   {-C,--continue-at}'[Resumed transfer OFFSET]':OFFSET \
```