### PR TITLE
build: Fix theoretical infinite loops

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -160,10 +160,10 @@ dist-hook:
 	done)
 
 html:
-	cd docs; make html
+	cd docs && make html
 
 pdf:
-	cd docs; make pdf
+	cd docs && make pdf
 
 check: test examples check-docs
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -45,10 +45,10 @@ MAN2HTML= roffit < $< >$@
 SUFFIXES = .1 .html .pdf
 
 html: $(HTMLPAGES)
-	cd libcurl; make html
+	cd libcurl && make html
 
 pdf: $(PDFPAGES)
-	cd libcurl; make pdf
+	cd libcurl && make pdf
 
 .1.html:
 	$(MAN2HTML)

--- a/docs/libcurl/Makefile.am
+++ b/docs/libcurl/Makefile.am
@@ -99,13 +99,13 @@ libcurl-symbols.3: $(srcdir)/symbols-in-versions $(srcdir)/mksymbolsmanpage.pl
 	perl $(srcdir)/mksymbolsmanpage.pl < $(srcdir)/symbols-in-versions > $@
 
 html: $(HTMLPAGES)
-	cd opts; make html
+	cd opts && make html
 
 .3.html:
 	$(MAN2HTML)
 
 pdf: $(PDFPAGES)
-	cd opts; make pdf
+	cd opts && make pdf
 
 .3.pdf:
 	@(foo=`echo $@ | sed -e 's/\.[0-9]$$//g'`; \


### PR DESCRIPTION
Add error-checking to `cd` in a few cases where omitting the checks might result in an infinite loop.

I haven't reviewed other uses of `cd foo; make ...` in the makefiles to determine their failure modes if their `cd` commands faied.