### PR TITLE
Cleaning up conditional directives that break statements.

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -520,11 +520,13 @@ CURLcode Curl_read_plain(curl_socket_t sockfd,
 
   if(-1 == nread) {
     int err = SOCKERRNO;
+    int return_error;
 #ifdef USE_WINSOCK
-    if(WSAEWOULDBLOCK == err)
+    return_error = WSAEWOULDBLOCK == err;
 #else
-    if((EWOULDBLOCK == err) || (EAGAIN == err) || (EINTR == err))
+    return_error = EWOULDBLOCK == err || EAGAIN == err || EINTR == err;
 #endif
+    if (return_error)
       return CURLE_AGAIN;
     else
       return CURLE_RECV_ERROR;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.