### PR TITLE
version: Add flag CURL_VERSION_PSL for libpsl

### DIFF
--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -76,9 +76,9 @@ typedef struct {
 .fi
 
 \fIage\fP describes what the age of this struct is. The number depends on how
-new the libcurl you're using is. You are however guaranteed to get a struct that you
-have a matching struct for in the header, as you tell libcurl your "age" with
-the input argument.
+new the libcurl you're using is. You are however guaranteed to get a struct
+that you have a matching struct for in the header, as you tell libcurl your
+"age" with the input argument.
 
 \fIversion\fP is just an ascii string for the libcurl version.
 
@@ -149,6 +149,10 @@ libcurl was built with support for HTTP2.
 .IP CURL_VERSION_UNIX_SOCKETS
 libcurl was built with support for Unix domain sockets.
 (Added in 7.40.0)
+.IP CURL_VERSION_PSL
+libcurl was built with support for Mozilla's Public Suffix List. This makes
+libcurl ignore cookies with a domain that's on the list.
+(Added in 7.47.0)
 .RE
 \fIssl_version\fP is an ASCII string for the OpenSSL version used. If libcurl
 has no SSL support, this is NULL.

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -779,6 +779,7 @@ CURL_VERSION_LARGEFILE          7.11.1
 CURL_VERSION_LIBZ               7.10
 CURL_VERSION_NTLM               7.10.6
 CURL_VERSION_NTLM_WB            7.22.0
+CURL_VERSION_PSL                7.47.0
 CURL_VERSION_SPNEGO             7.10.8
 CURL_VERSION_SSL                7.10
 CURL_VERSION_SSPI               7.13.2

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2329,6 +2329,8 @@ typedef struct {
 #define CURL_VERSION_GSSAPI       (1<<17) /* Built against a GSS-API library */
 #define CURL_VERSION_KERBEROS5    (1<<18) /* Kerberos V5 auth is supported */
 #define CURL_VERSION_UNIX_SOCKETS (1<<19) /* Unix domain sockets support */
+#define CURL_VERSION_PSL          (1<<20) /* Mozilla's Public Suffix List, used
+                                             for cookie domain verification */
 
  /*
  * NAME curl_version_info()

--- a/lib/version.c
+++ b/lib/version.c
@@ -306,6 +306,9 @@ static curl_version_info_data version_info = {
 #if defined(USE_UNIX_SOCKETS)
   | CURL_VERSION_UNIX_SOCKETS
 #endif
+#if defined(USE_LIBPSL)
+  | CURL_VERSION_PSL
+#endif
   ,
   NULL, /* ssl_version */
   0,    /* ssl_version_num, this is kept at zero */


### PR DESCRIPTION
As proposed by Gisle Vanem in 
https://github.com/bagder/curl/commit/e77b5b7453c1e8ccd7ec0816890d98e2f392e465#commitcomment-14739692
If there are no objections I'll land it in a few days