### PR TITLE
Fix compilation error with CURL_DISABLE_VERBOSE_STRINGS

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -567,7 +567,7 @@ output_auth_headers(struct connectdata *conn,
 {
   const char *auth = NULL;
   CURLcode result = CURLE_OK;
-#if defined(USE_SPNEGO) || !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(USE_SPNEGO)
   struct SessionHandle *data = conn->data;
 #endif
 #ifdef USE_SPNEGO


### PR DESCRIPTION
With curl disable verbose strings in http.c the compilation fails due to the data variable being undefined later on in the function.