### PR TITLE
Add .dir-locals and set c-basic-offset to 2.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+;;; Directory Local Variables
+;;; See Info node `(emacs) Directory Variables' for more information.
+
+((c-mode
+  (c-basic-offset . 2))
+ (c++-mode
+  (c-basic-offset . 2)))


### PR DESCRIPTION
This makes it easier for emacs users to automatically get the right
2-space indentation when they edit curl source files.