### PR TITLE
mbedtls: Implement CURLOPT_PINNEDPUBLICKEY

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -91,8 +91,9 @@ footer:
 .fi
 .SH AVAILABILITY
 Added in 7.39.0 for OpenSSL, GnuTLS and GSKit. Added in 7.43.0 for
-NSS and wolfSSL/CyaSSL. sha256 support added in 7.44.0 for OpenSSL,
-GnuTLS, NSS and wolfSSL/CyaSSL. Other SSL backends not supported.
+NSS and wolfSSL/CyaSSL. Added for mbedtls in 7.47.0, sha256 support
+added in 7.44.0 for OpenSSL, GnuTLS, NSS and wolfSSL/CyaSSL. Other
+SSL backends not supported.
 .SH RETURN VALUE
 Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -153,7 +153,7 @@ mbedtls_verify_pinned_crt(void *p, mbedtls_x509_crt *crt,
   unsigned char *pinned_cert = data->set.str[STRING_SSL_PINNEDPUBLICKEY];
 
   /* Skip intermediate and root certificates */
-  if (depth){
+  if(depth) {
     return 0;
   }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -141,6 +141,44 @@ const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_fr =
     1024,      /* RSA min key len */
 };
 
+static int
+mbedtls_verify_pinned_crt(void *p, mbedtls_x509_crt *crt,
+                          int depth, unsigned int *flags)
+{
+  struct SessionHandle *data = p;
+  unsigned char pubkey[1024];
+  unsigned int i;
+  int ret;
+  int size;
+  unsigned char *pinned_cert = data->set.str[STRING_SSL_PINNEDPUBLICKEY];
+
+  /* Skip intermediate and root certificates */
+  if (depth){
+    return 0;
+  }
+
+  if(pinned_cert == NULL || crt == NULL) {
+    *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
+    return 1;
+  }
+
+  /* Extract pubkey */
+  size = mbedtls_pk_write_pubkey_der(&crt->pk, pubkey, 1024);
+  if(size <= 0) {
+    *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
+    return 1;
+  }
+
+  /* mbedtls_pk_write_pubkey_der writes data at the end of the buffer */
+  ret = Curl_pin_peer_pubkey(data, pinned_cert, &pubkey[1024 - size], size);
+  if(ret == CURLE_OK) {
+    return 0;
+  }
+
+  *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
+  return 1;
+}
+
 static Curl_recv mbedtls_recv;
 static Curl_send mbedtls_send;
 
@@ -625,6 +663,10 @@ mbedtls_connect_common(struct connectdata *conn,
   curl_socket_t sockfd = conn->sock[sockindex];
   long timeout_ms;
   int what;
+
+  if(data->set.str[STRING_SSL_PINNEDPUBLICKEY]) {
+    mbedtls_ssl_conf_verify(&connssl->config, mbedtls_verify_pinned_crt, data);
+  }
 
   /* check if the connection has already been established */
   if(ssl_connection_complete == connssl->state) {

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -162,7 +162,7 @@ mbedtls_verify_pinned_crt(void *p, mbedtls_x509_crt *crt,
     return 1;
   }
 
-  /* Determine pubkey size in bits */
+  /* Determine pubkey size in bytes */
   pubkey_len = mbedtls_pk_get_len(&crt->pk);
   if(pubkey_len <= 0) {
     *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -141,13 +141,21 @@ const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_fr =
     1024,      /* RSA min key len */
 };
 
+/* See https://tls.mbed.org/discussions/generic/
+   howto-determine-exact-buffer-len-for-mbedtls_pk_write_pubkey_der
+*/
+#define RSA_PUB_DER_MAX_BYTES   (38 + 2 * MBEDTLS_MPI_MAX_SIZE)
+#define ECP_PUB_DER_MAX_BYTES   (30 + 2 * MBEDTLS_ECP_MAX_BYTES)
+
+#define PUB_DER_MAX_BYTES   (RSA_PUB_DER_MAX_BYTES > ECP_PUB_DER_MAX_BYTES ? \
+                            RSA_PUB_DER_MAX_BYTES : ECP_PUB_DER_MAX_BYTES)
+
 static int
 mbedtls_verify_pinned_crt(void *p, mbedtls_x509_crt *crt,
                           int depth, unsigned int *flags)
 {
   struct SessionHandle *data = p;
-  unsigned char *pubkey;
-  size_t pubkey_len;
+  unsigned char pubkey[PUB_DER_MAX_BYTES];
   int ret;
   int size;
   unsigned char *pinned_cert = data->set.str[STRING_SSL_PINNEDPUBLICKEY];
@@ -162,39 +170,20 @@ mbedtls_verify_pinned_crt(void *p, mbedtls_x509_crt *crt,
     return 1;
   }
 
-  /* Determine pubkey size in bytes */
-  pubkey_len = mbedtls_pk_get_len(&crt->pk);
-  if(pubkey_len <= 0) {
-    *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-    return 1;
-  }
-
-  /* FIXME: How to determine the exact size necessary? */
-  pubkey_len *= 2;
-
-  pubkey = malloc(pubkey_len);
-  if(pubkey == NULL) {
-    *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-    return 1;
-  }
-
   /* Extract pubkey */
-  size = mbedtls_pk_write_pubkey_der(&crt->pk, pubkey, pubkey_len);
+  size = mbedtls_pk_write_pubkey_der(&crt->pk, pubkey, PUB_DER_MAX_BYTES);
   if(size <= 0) {
     *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-    free(pubkey);
     return 1;
   }
 
   /* mbedtls_pk_write_pubkey_der writes data at the end of the buffer. */
-  ret = Curl_pin_peer_pubkey(data, pinned_cert, &pubkey[pubkey_len - size], size);
+  ret = Curl_pin_peer_pubkey(data, pinned_cert, &pubkey[PUB_DER_MAX_BYTES - size], size);
   if(ret == CURLE_OK) {
-    free(pubkey);
     return 0;
   }
 
   *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-  free(pubkey);
   return 1;
 }
 

--- a/lib/vtls/mbedtls.h
+++ b/lib/vtls/mbedtls.h
@@ -63,6 +63,7 @@ int Curl_mbedtls_shutdown(struct connectdata *conn, int sockindex);
 #define curlssl_check_cxn(x) (x=x, -1)
 #define curlssl_data_pending(x,y) (x=x, y=y, 0)
 #define CURL_SSL_BACKEND CURLSSLBACKEND_MBEDTLS
+#define curlssl_sha256sum(a,b,c,d) mbedtls_sha256(a,b,c,0)
 
 /* This might cause libcurl to use a weeker random!
    TODO: implement proper use of Polarssl's CTR-DRBG or HMAC-DRBG and use that


### PR DESCRIPTION
Hello,
this implements CURLOPT_PINNEDPUBLICKEY for mbedtls. I tested it with sha256// on mingw-win32 and Linux. I have it in production for 20 users since one week. Please review and merge. I'm happy to work in any improvements.

Cheers,
     Thomas