### PR TITLE
Fix connection reuse with IDN host names

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -168,4 +168,4 @@ test2008 test2009 test2010 test2011 test2012 test2013 test2014 test2015 \
 test2016 test2017 test2018 test2019 test2020 test2021 test2022 test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \
 test2032 test2033 test2034 test2035 test2036 test2037 test2038 test2039 \
-test2040 test2041 test2042 test2043 test2044 test2045
+test2040 test2041 test2042 test2043 test2044 test2045 test2046 test2047

--- a/tests/data/test2046
+++ b/tests/data/test2046
@@ -1,0 +1,94 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+IDN
+followlocation
+--write-out
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 302 OK swsbounce
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Content-Type: text/plain
+Location: ./20460001
+
+redirect
+</data>
+<data1 nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 3
+Content-Type: text/plain; charset=us-ascii
+
+OK
+</data1>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+idn
+</features>
+<setenv>
+CHARSET=UTF-8
+</setenv>
+ <name>
+Connection re-use with IDN host name
+ </name>
+
+ <command>
+http://åäö.se:%HTTPPORT/2046 --resolve xn--4cab6c.se:%HTTPPORT:%HOSTIP -w "%{num_connects}\n%{num_redirects}\n%{size_download}\n%{url_effective}\n%{content_type}\n%{response_code}\n" -L
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /2046 HTTP/1.1
+Host: xn--4cab6c.se:%HTTPPORT
+Accept: */*
+
+GET /20460001 HTTP/1.1
+Host: xn--4cab6c.se:%HTTPPORT
+Accept: */*
+
+</protocol>
+
+<stdout>
+HTTP/1.1 302 OK swsbounce
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Content-Type: text/plain
+Location: ./20460001
+
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 3
+Content-Type: text/plain; charset=us-ascii
+
+OK
+1
+1
+3
+http://åäö.se:%HTTPPORT/20460001
+text/plain; charset=us-ascii
+200
+</stdout>
+
+</verify>
+</testcase>

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -1,0 +1,97 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+IDN
+followlocation
+--write-out
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 302 OK swsbounce
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Content-Type: text/plain
+Location: ./20470001
+
+redirect
+</data>
+<data1 nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 3
+Content-Type: text/plain; charset=us-ascii
+
+OK
+</data1>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+idn
+</features>
+<setenv>
+CHARSET=UTF-8
+</setenv>
+ <name>
+Connection re-use with IDN host name over HTTP proxy
+ </name>
+
+ <command>
+http://åäö.se/2047 -x %HOSTIP:%HTTPPORT -w "%{num_connects}\n%{num_redirects}\n%{size_download}\n%{url_effective}\n%{content_type}\n%{response_code}\n" -L
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://xn--4cab6c.se/2047 HTTP/1.1
+Host: xn--4cab6c.se
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://xn--4cab6c.se/20470001 HTTP/1.1
+Host: xn--4cab6c.se
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+
+<stdout>
+HTTP/1.1 302 OK swsbounce
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Content-Type: text/plain
+Location: ./20470001
+
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 3
+Content-Type: text/plain; charset=us-ascii
+
+OK
+1
+1
+3
+http://xn--4cab6c.se/20470001
+text/plain; charset=us-ascii
+200
+</stdout>
+
+</verify>
+</testcase>


### PR DESCRIPTION
Always use the ACE form of IDN hostnames as key in the connection cache.

Previously, curl created multiple connections when following redirections from a server with an IDN hostname, e.g. http://äöü.example.com/page1 --> http://äöü.example.com/page2 . The Unicode hostname was used as a key for the connection cache, and for the second request, the ACE name was used to search an existing connection. Therefore curl did not find the existing connection.