### PR TITLE
Remove the port number from IDN host names before converting to ACE

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -5652,13 +5652,6 @@ static CURLcode create_conn(struct SessionHandle *data,
     conn->bits.tunnel_proxy = TRUE;
 
   /*************************************************************
-   * IDN-fix the hostnames
-   *************************************************************/
-  fix_hostname(data, conn, &conn->host);
-  if(conn->proxy.name && *conn->proxy.name)
-    fix_hostname(data, conn, &conn->proxy);
-
-  /*************************************************************
    * Figure out the remote port number and fix it in the URL
    *************************************************************/
   result = parse_remote_port(data, conn);
@@ -5673,6 +5666,13 @@ static CURLcode create_conn(struct SessionHandle *data,
   result = set_login(conn, user, passwd, options);
   if(result)
     goto out;
+
+  /*************************************************************
+   * IDN-fix the hostnames
+   *************************************************************/
+  fix_hostname(data, conn, &conn->host);
+  if(conn->proxy.name && *conn->proxy.name)
+    fix_hostname(data, conn, &conn->proxy);
 
   /*************************************************************
    * Setup internals depending on protocol. Needs to be done after


### PR DESCRIPTION
This is a follow-up to pull request #592 . The port number should be removed from a host name before the host name is converted to ACE. The port number is removed by parse_remote_port(), so this function must be called before fix_hostname().

Surprisingly, the tests passed before this commit, so I think that libidn actually supports port numbers in host names. But I'm not sure whether other IDN libraries (e.g. on Windows) also support port numbers.