### PR TITLE
lib: Prefix URLs with lower-case protocol names/schemes

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -5509,6 +5509,7 @@ static CURLcode create_conn(struct SessionHandle *data,
        we're gonna follow a Location: later or... then we need the protocol
        part added so that we have a valid URL. */
     char *reurl;
+    char *ch_lower;
 
     reurl = aprintf("%s://%s", conn->handler->scheme, data->change.url);
 
@@ -5516,6 +5517,10 @@ static CURLcode create_conn(struct SessionHandle *data,
       result = CURLE_OUT_OF_MEMORY;
       goto out;
     }
+
+    /* Change protocol prefix to lower-case */
+    for(ch_lower = reurl; *ch_lower != ':'; ch_lower++)
+      *ch_lower = (char)TOLOWER(*ch_lower);
 
     if(data->change.url_alloc) {
       Curl_safefree(data->change.url);

--- a/tests/data/test1213
+++ b/tests/data/test1213
@@ -43,7 +43,7 @@ HTTP with proxy and host-only URL
 ^User-Agent:.*
 </strip>
 <protocol>
-GET HTTP://we.want.that.site.com.1213/ HTTP/1.1
+GET http://we.want.that.site.com.1213/ HTTP/1.1
 Host: we.want.that.site.com.1213
 Accept: */*
 Proxy-Connection: Keep-Alive


### PR DESCRIPTION
  Before this patch, if a URL does not start with the protocol
  name/scheme, effective URLs would be prefixed with upper-case
  protocol names/schemes. This behavior might not be expected by
  library users or end users.

  For example, if `CURLOPT_DEFAULT_PROTOCOL` is set to "https". And
  the URL is "hostname/path". The effective URL would be
  "HTTPS://hostname/path" instead of "https://hostname/path".

  After this patch, effective URLs would be prefixed with
  a lower-case protocol name/scheme.