### PR TITLE
Use just-built curl to generate zsh completion

### DIFF
--- a/scripts/zsh.pl
+++ b/scripts/zsh.pl
@@ -5,7 +5,7 @@
 use strict;
 use warnings;
 
-my $curl = $ARGV[0] || 'curl';
+my $curl = $ARGV[0] || '../src/curl';
 
 my $regex = '\s+(?:(-[^\s]+),\s)?(--[^\s]+)\s([^\s.]+)?\s+(.*)';
 my @opts = parse_main_opts('--help', $regex);


### PR DESCRIPTION
In a Linux build environment curl is built in a chroot where there is no curl installed on the system. In that case currently curl fails to build zsh completion. Producing a broken _curl file. Instead we can use the just-built curl binary to generate zsh completion. This way completion will also be always up-to-date with new options too.