### PR TITLE
add example for CURLINFO_RESPONSE_CODE

### DIFF
--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -38,7 +38,19 @@ Support for SMTP responses added in 7.25.0.
 .SH PROTOCOLS
 HTTP, FTP and SMTP
 .SH EXAMPLE
-TODO
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  CURLcode res;
+  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  res = curl_easy_perform(curl);
+  if (res == CURLE_OK) {
+    long response_code;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  }
+  curl_easy_cleanup(curl);
+}
+.fi
 .SH AVAILABILITY
 Added in 7.10.8. CURLINFO_HTTP_CODE was added in 7.4.1.
 .SH RETURN VALUE


### PR DESCRIPTION
Hi!

I was reading the man page for `CURLINFO_RESPONSE_CODE` today and noticed that the example section only contains `TODO`. This adds a simple example to it.

Please let me know if there's anything that needs change or I should do additionally.